### PR TITLE
ci: add license check workflow

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,28 @@
+name: License Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  license-check:
+    name: Check licenses
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses/v2@latest
+
+      - name: Check licenses
+        run: go-licenses check ./... --disallowed_types=forbidden,restricted,reciprocal --include_tests


### PR DESCRIPTION
Add GitHub Actions workflow to check Go dependencies licenses using go-licenses tool. The workflow runs on push to main and on pull requests, checking for forbidden, restricted, and reciprocal licenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)