### PR TITLE
feat: add cooldown configuration to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+    cooldown:
+      default-days: 5
     groups:
       aws-sdk:
         patterns:
@@ -20,3 +22,5 @@ updates:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
       day: "friday"
+    cooldown:
+      default-days: 5


### PR DESCRIPTION
## Summary

- Add 5-day cooldown configuration to Dependabot for both `gomod` and `github-actions` package ecosystems
- This allows time to detect potential issues with new package versions before PRs are created

## Changes

- Added `cooldown.default-days: 5` to gomod ecosystem
- Added `cooldown.default-days: 5` to github-actions ecosystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)