### PR TITLE
fix: correct command name in diff error message and add silent mode c…

### DIFF
--- a/internal/diff/display.go
+++ b/internal/diff/display.go
@@ -18,7 +18,10 @@ func displaySilent(result *Result, deployment *aws.DeploymentInfo) {
 		displayColorizedDiff(result.UnifiedDiff)
 	}
 
-	// Show deployment warning in silent mode too if deployment is in progress
+	// Show deployment warning in silent mode too if deployment is in progress.
+	// This is intentional because an ongoing deployment that gets rolled back
+	// could change the diff result, and users should be aware of this risk
+	// even in silent/automated environments.
 	displayDeploymentWarning(deployment)
 }
 

--- a/internal/diff/executor.go
+++ b/internal/diff/executor.go
@@ -78,7 +78,7 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 		fmt.Fprintln(os.Stderr, "\nLocal configuration:")
 		fmt.Println(string(localData))
 		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "Run 'apcdeploy deploy' to create the first deployment.")
+		fmt.Fprintln(os.Stderr, "Run 'apcdeploy run' to create the first deployment.")
 		return nil
 	}
 


### PR DESCRIPTION
…omment

- Fix incorrect command name in error message (deploy -> run) in internal/diff/executor.go
- Add explanatory comment for warning display in silent mode in internal/diff/display.go
  - Explains that deployment warnings are shown even in silent mode because ongoing deployments that get rolled back could change the diff result

🤖 Generated with [Claude Code](https://claude.com/claude-code)