### PR TITLE
docs: add llms.md and fix deployment strategy documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ Defined in `internal/config/constants.go`:
 application: <name>
 configuration_profile: <name>
 environment: <name>
-deployment_strategy: <strategy-name>  # optional, defaults to AppConfig.Linear50PercentEvery30Seconds
+deployment_strategy: <strategy-name>  # optional, defaults to AppConfig.AllAtOnce
 data_file: <path>  # relative to apcdeploy.yml or absolute
 region: <aws-region>  # optional, uses AWS SDK default if omitted
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Example `apcdeploy.yml`:
 application: my-application
 configuration_profile: my-config-profile
 environment: production
-deployment_strategy: AppConfig.Linear50PercentEvery30Seconds
+deployment_strategy: AppConfig.AllAtOnce  # optional, uses default if omitted
 data_file: data.json
 region: us-west-2
 ```
@@ -152,7 +152,7 @@ configuration_profile: my-config-profile
 # Required: Name of the environment
 environment: production
 
-# Optional: Deployment strategy (defaults to AppConfig.Linear50PercentEvery30Seconds)
+# Optional: Deployment strategy (defaults to AppConfig.AllAtOnce)
 deployment_strategy: AppConfig.AllAtOnce
 
 # Required: Path to your configuration data file (relative or absolute)
@@ -171,6 +171,8 @@ region: us-west-2
 For FeatureFlags profiles, metadata fields (`_createdAt`, `_updatedAt`) are automatically ignored during diff and deployment comparisons.
 
 ## Commands
+
+For detailed usage information and advanced features, see [llms.md](./llms.md).
 
 ### Global Flags
 


### PR DESCRIPTION
resolve https://github.com/koh-sh/apcdeploy/issues/18

- Add llms.md: comprehensive guidelines for AI assistants using apcdeploy
  - Detailed command reference with usage examples
  - IAM permissions requirements
  - Best practices and troubleshooting guides
  - Configuration file reference

- Fix default deployment strategy documentation
  - Correct default from AppConfig.Linear50PercentEvery30Seconds to AppConfig.AllAtOnce
  - Update CLAUDE.md and README.md examples

- Fix IAM permissions in llms.md
  - Remove unused permissions: appconfig:GetApplication, appconfig:GetEnvironment
  - Add missing permission: appconfig:ListDeployments (used by diff, status, run)
  - Correct service prefix for Data API permissions

- Add reference to llms.md in README.md Commands section

🤖 Generated with [Claude Code](https://claude.com/claude-code)