### PR TITLE
chore(goreleaser): drop redundant before-hooks block

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,12 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
 version: 2
-before:
-  hooks:
-    # You may remove this if you don't use go modules.
-    - go mod tidy
-    # you may remove this if you don't need go generate
-    #- go generate ./...
 builds:
   - env:
       - CGO_ENABLED=0


### PR DESCRIPTION
## Summary

Removes the GoReleaser starter-template `before.hooks: - go mod tidy` block. The hook can never legitimately mutate `go.mod` at release time — tags are cut on a green main where `Go Test` has already exercised the build with the committed `go.mod`/`go.sum`. Dropping it also removes any chance of the release pipeline rewriting dependencies behind the released tag.

The macOS Homebrew Cask `post.install` xattr hook is **intentionally kept**: binaries ship unsigned (no `codesign` / notarization in `.goreleaser.yaml` or any GitHub Actions workflow), so removing the `xattr -dr com.apple.quarantine` step would have macOS Gatekeeper block `apcdeploy` on first launch.

## Test plan

- [x] `goreleaser check` passes against the modified config

🤖 Generated with [Claude Code](https://claude.com/claude-code)