### PR TITLE
refactor(reporter): introduce Checklist primitive and redesign command output

### DIFF
--- a/.claude/rules/output-contract.md
+++ b/.claude/rules/output-contract.md
@@ -36,13 +36,23 @@ silent-mode behavior, and visual treatment.
 | `Header(title)` | stderr | suppressed | bold + rule line | Section heading (e.g. "Configuration Diff") |
 | `Box(title, lines)` | stderr | suppressed | bordered card | Multi-line panel (e.g. init's "Next steps") |
 | `Table(headers, rows)` | stderr | suppressed | lipgloss table | Structured key/value or row data |
-| `Spin(msg) Spinner` | stderr | suppressed; non-TTY: `Step` once | animated frames | Live indicator wrapping a long call |
+| `Spin(msg) Spinner` | stderr | suppressed; non-TTY: silent until `Done`/`Fail` emits the completion line | animated frames | Single-phase live indicator wrapping a long call |
+| `Checklist(items) Checklist` | stderr | suppressed; non-TTY: silent except completion line per `Done`/`Fail`/`Skip` | live block of `○ ⠋ ✓ ✗ →` items | Multi-phase progress where every phase is known up-front |
 | `Progress(msg) ProgressBar` | stderr | suppressed; non-TTY: `Step` at thresholds | live bar with `[####  ] 50%` | Percentage progress for long operations (deployment monitoring) |
 | `Data(p []byte)` | **stdout** | **always shown** | none | Machine-readable payload |
 | `Diff(p []byte)` | **stdout** | **always shown** | colorized when TTY | Unified diff payload |
 
 `Spinner` is `interface { Done(msg string); Fail(msg string) }`. `Done` emits a
 `Success`-equivalent line; `Fail` emits an `Error`-equivalent line on stderr.
+
+`Checklist` is `interface { Start(idx int); Done(idx int, msg string); Fail(idx
+int, msg string); Skip(idx int, msg string); Close() }`. Items are referenced
+by their zero-based index in the labels slice. `Start` flips an item to the
+animated state, `Done`/`Fail`/`Skip` finalize it (with `msg` overriding the
+original label when non-empty), and `Close` releases the rendering goroutine
+(callers MUST invoke it exactly once — defer it). Use `Checklist` instead of a
+sequence of `Spin` calls when the work has a known, multi-phase plan; use
+`Spin` for one-off long calls.
 
 `ProgressBar` is `interface { Update(percent float64, msg string); Done(msg
 string); Fail(msg string); Stop() }`. `Update` advances the bar (`percent` is
@@ -69,7 +79,7 @@ Reporter kind — they live in `internal/prompt`. The contract for confirmations
 silent variant. Rules:
 
 - Silent mode suppresses Step / Success / Info / Warn / Header / Box / Table /
-  Spin / Progress entirely.
+  Spin / Checklist / Progress entirely.
 - Silent mode preserves Error (always to stderr) and Data / Diff (always to
   stdout) so scripts still receive errors and payloads.
 - Silent mode does NOT change confirmation behavior — the user still must pass
@@ -82,8 +92,12 @@ silent variant. Rules:
 
 When stderr is not a TTY (CI, pipes, redirects), the Reporter degrades:
 
-- `Spin` collapses to a single `Step` line; `Spinner.Done`/`Fail` emit a
-  matching `Success`/`Error` line.
+- `Spin` stays silent until the caller invokes `Done`/`Fail`, which emit a
+  single `Success`/`Error` line. The starting message is dropped so logs only
+  record terminal states.
+- `Checklist` likewise stays silent until each item's `Done`/`Fail`/`Skip`
+  fires; those emit a `Success`/`Error`/`Info` line respectively. There is no
+  pre-printed pending list and no per-item Start announcement.
 - `Progress` collapses to coarse `Step` lines emitted only when crossing 25 /
   50 / 75 / 100 % thresholds; `ProgressBar.Done`/`Fail` emit the same
   `Success`/`Error` lines as the TTY path.
@@ -96,8 +110,10 @@ When stderr is not a TTY (CI, pipes, redirects), the Reporter degrades:
 
 - All color comes from `lipgloss` styles defined in `internal/cli/style.go`.
 - `lipgloss` honors `NO_COLOR`; setting it disables color globally.
-- Symbols (`⏳ ✓ ℹ ⚠ ✗`) MUST be the only emoji-like glyphs used. No other
-  emoji in CLI output.
+- Symbols (`⏳ ✓ ℹ ⚠ ✗ ○ →`) MUST be the only emoji-like glyphs used. `○` and
+  `→` are reserved for `Checklist` (pending and skip respectively); the rest
+  are used as line prefixes by their corresponding kinds. No other emoji in
+  CLI output.
 
 ## Documented exceptions
 
@@ -134,7 +150,12 @@ without adding a similar entry here.
 
 1. Decide what (if anything) goes to stdout — that is your `Data` or `Diff` payload.
 2. Pick Reporter kinds for everything else. A typical command issues:
-   `Step` → `Success` for each phase, optional `Header` + `Table` for a final
-   summary, `Box` for next-step guidance.
+   - One `Spin` for a single AWS round-trip, OR a `Checklist` for a known
+     multi-phase plan (defer `Close()` immediately).
+   - Optional `Header` + `Table` for a final summary; `Box` for next-step
+     guidance.
+   - Do not emit a `Step` for instant operations (file reads, validation,
+     content-type detection). Failures will surface via the returned error;
+     the absence of an error is the success signal.
 3. Wire the command to `cli.GetReporter(silent)` in `cmd/<name>.go`.
 4. Do not branch on `opts.Silent` inside the executor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ Configuration file management:
 
 The single output abstraction used by every command. See [Output Contract](.claude/rules/output-contract.md) for the full contract.
 
-- `Reporter`: Interface with `Step`, `Success`, `Info`, `Warn`, `Error`, `Header`, `Box`, `Table`, `Spin`, `Progress`, `Data`, `Diff`
+- `Reporter`: Interface with `Step`, `Success`, `Info`, `Warn`, `Error`, `Header`, `Box`, `Table`, `Spin`, `Checklist`, `Progress`, `Data`, `Diff`
 - `internal/cli/reporter.go`: TTY-aware console implementation using lipgloss styles + bubbles spinner frames
 - `internal/cli/silent_reporter.go`: Silent variant that suppresses everything except `Error` / `Data` / `Diff`
 - `internal/cli/style.go`: Centralized lipgloss styles (the only place ANSI/color is defined)
@@ -357,7 +357,7 @@ region: <aws-region>  # optional, uses AWS SDK default if omitted
 
 ## Output Contract
 
-Every command produces output through `internal/reporter`. The full contract — channels (stdout vs stderr), output kinds (Step/Success/Info/Warn/Error/Header/Box/Table/Spin/Data/Diff), `--silent` semantics, TTY degradation, and rules for adding new commands — lives in [.claude/rules/output-contract.md](.claude/rules/output-contract.md).
+Every command produces output through `internal/reporter`. The full contract — channels (stdout vs stderr), output kinds (Step/Success/Info/Warn/Error/Header/Box/Table/Spin/Checklist/Progress/Data/Diff), `--silent` semantics, TTY degradation, and rules for adding new commands — lives in [.claude/rules/output-contract.md](.claude/rules/output-contract.md).
 
 Quick reference:
 

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -37,11 +37,16 @@ $APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region
 use_strategy
 echo '{"v":"1"}' > data.json
 echo "Test verbose output (without --silent) to verify detailed logging works"
-$APCDEPLOY diff 2>&1 | grep -q "Resolving resources"
-$APCDEPLOY diff 2>&1 | grep -q "Fetching latest deployment"
+# diff folds resolve + fetch-deployment + fetch-config into a single spinner.
+# In non-TTY mode the spinner emits only its Done line, which differs by
+# whether a prior deployment exists ("Loaded deployment data ..." vs "No prior
+# deployment ..."). The test only cares that *some* progress reaches stderr
+# (the spinner is the user-visible signal that work is happening), so we
+# match either message.
+$APCDEPLOY diff 2>&1 | grep -qE "(Loaded deployment data|No prior deployment)"
 $APCDEPLOY diff | grep -q "v"
 echo "Test silent mode suppresses verbose output"
-if $APCDEPLOY diff --silent 2>&1 | grep -q "Resolving resources"; then
+if $APCDEPLOY diff --silent 2>&1 | grep -qE "(Loaded deployment data|No prior deployment)"; then
     echo "ERROR: Silent mode should not show progress messages"
     exit 1
 fi
@@ -172,9 +177,10 @@ echo "Edge cases: no deployment history, invalid timeout, missing required flags
 title "========== E5: Edge Cases =========="
 $APCDEPLOY init --silent --app "$APP" --profile error-test --env staging --region "$REGION" --force
 use_strategy
-# Run without `--silent` because the "no deployment" notice is a Reporter.Warn
-# which silent mode suppresses by contract.
-$APCDEPLOY diff 2>&1 | grep -q "No deployment" || echo "⚠️  Deployment may exist"
+# Run without `--silent` because the "no deployment" notice is now the spinner
+# Done message wrapping the deployment fetch — silent mode suppresses spinner
+# output (only Error / Data / Diff survive).
+$APCDEPLOY diff 2>&1 | grep -q "No prior deployment" || echo "⚠️  Deployment may exist"
 $APCDEPLOY status 2>&1 | grep -q "No deploy" || echo "⚠️  Deployment may exist"
 
 # pull and edit must exit 2 (not 1) so scripts can distinguish "no prior deployment" from real errors.

--- a/internal/cli/checklist.go
+++ b/internal/cli/checklist.go
@@ -1,0 +1,290 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	bspinner "github.com/charmbracelet/bubbles/spinner"
+	"github.com/koh-sh/apcdeploy/internal/reporter"
+)
+
+// itemState is the lifecycle state of a single checklist item.
+type itemState int
+
+const (
+	statePending itemState = iota
+	stateActive
+	stateDone
+	stateFail
+	stateSkip
+)
+
+// checklistItem holds the rendered label and current state.
+type checklistItem struct {
+	label string
+	msg   string // overrides label once state != pending
+	state itemState
+}
+
+// ttyChecklist is the TTY implementation of reporter.Checklist. It pre-prints
+// every item as pending (○), then redraws the whole block in place when state
+// changes. A goroutine ticks at the spinner FPS to animate the active item's
+// frame; redrawing the entire block on each tick (rather than only the active
+// line) keeps the cursor math trivial.
+type ttyChecklist struct {
+	w        io.Writer
+	items    []checklistItem
+	frames   []string
+	fps      time.Duration
+	frameIdx int
+
+	mu     sync.Mutex
+	closed bool
+	stop   chan struct{}
+	done   chan struct{}
+}
+
+// newTTYChecklist constructs and renders the initial pending block.
+func newTTYChecklist(w io.Writer, labels []string) *ttyChecklist {
+	items := make([]checklistItem, len(labels))
+	for i, l := range labels {
+		items[i] = checklistItem{label: l, state: statePending}
+	}
+	fps := bspinner.MiniDot.FPS
+	if fps <= 0 {
+		fps = time.Second / 12
+	}
+	c := &ttyChecklist{
+		w:      w,
+		items:  items,
+		frames: bspinner.MiniDot.Frames,
+		fps:    fps,
+		stop:   make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	c.renderInitial()
+	go c.animate()
+	return c
+}
+
+// renderInitial prints every item line followed by a newline. After this the
+// cursor sits on the line directly below the last item; subsequent redraws
+// move up by len(items) to reach the top of the block.
+func (c *ttyChecklist) renderInitial() {
+	for _, it := range c.items {
+		fmt.Fprintln(c.w, c.formatLine(it, c.frames[0]))
+	}
+}
+
+// redraw rewrites the entire block in place. Called both on state changes and
+// from the animation ticker for the active spinner frame.
+func (c *ttyChecklist) redraw() {
+	frame := c.frames[c.frameIdx%len(c.frames)]
+	// Move cursor up to the first item's line.
+	fmt.Fprintf(c.w, "\033[%dA", len(c.items))
+	for _, it := range c.items {
+		// \r moves to col 0; \033[K clears to end of line; \n advances.
+		fmt.Fprintf(c.w, "\r\033[K%s\n", c.formatLine(it, frame))
+	}
+}
+
+// formatLine renders a single item with its symbol + (label or msg).
+func (c *ttyChecklist) formatLine(it checklistItem, activeFrame string) string {
+	text := it.label
+	if it.msg != "" {
+		text = it.msg
+	}
+	switch it.state {
+	case stateActive:
+		return styles.step.Render(activeFrame) + " " + text
+	case stateDone:
+		return styles.success.Render(symSuccess) + " " + text
+	case stateFail:
+		return styles.errorS.Render(symError) + " " + text
+	case stateSkip:
+		return styles.subtle.Render(symSkip) + " " + styles.subtle.Render(text)
+	default:
+		return styles.subtle.Render(symPending) + " " + styles.subtle.Render(text)
+	}
+}
+
+func (c *ttyChecklist) animate() {
+	defer close(c.done)
+	ticker := time.NewTicker(c.fps)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.mu.Lock()
+			if c.closed {
+				c.mu.Unlock()
+				return
+			}
+			c.frameIdx++
+			c.redraw()
+			c.mu.Unlock()
+		}
+	}
+}
+
+// Start transitions an item to the active state.
+func (c *ttyChecklist) Start(idx int) { c.transition(idx, stateActive, "") }
+
+// Done transitions an item to the done state with an optional new message.
+func (c *ttyChecklist) Done(idx int, msg string) { c.transition(idx, stateDone, msg) }
+
+// Fail transitions an item to the failed state with an optional new message.
+func (c *ttyChecklist) Fail(idx int, msg string) { c.transition(idx, stateFail, msg) }
+
+// Skip transitions an item to the skipped state with an optional new message.
+func (c *ttyChecklist) Skip(idx int, msg string) { c.transition(idx, stateSkip, msg) }
+
+func (c *ttyChecklist) transition(idx int, state itemState, msg string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed || idx < 0 || idx >= len(c.items) {
+		return
+	}
+	c.items[idx].state = state
+	if msg != "" {
+		c.items[idx].msg = msg
+	}
+	c.redraw()
+}
+
+// Close stops the animation goroutine. The final block remains on screen.
+func (c *ttyChecklist) Close() {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	c.mu.Unlock()
+	close(c.stop)
+	<-c.done
+	// Final redraw with the resting frame so the spinner glyph isn't left
+	// frozen mid-animation if an item was active at Close time.
+	c.mu.Lock()
+	c.redraw()
+	c.mu.Unlock()
+}
+
+// nonTTYChecklist emits one Success/Error/Info line per Done/Fail/Skip
+// transition. Pending and Start are silent, matching the user-facing
+// requirement that non-TTY logs carry only terminal states.
+type nonTTYChecklist struct {
+	r        *Reporter
+	items    []checklistItem
+	mu       sync.Mutex
+	closed   bool
+	finished []bool
+}
+
+func newNonTTYChecklist(r *Reporter, labels []string) *nonTTYChecklist {
+	items := make([]checklistItem, len(labels))
+	for i, l := range labels {
+		items[i] = checklistItem{label: l, state: statePending}
+	}
+	return &nonTTYChecklist{
+		r:        r,
+		items:    items,
+		finished: make([]bool, len(labels)),
+	}
+}
+
+func (c *nonTTYChecklist) Start(int) {}
+
+func (c *nonTTYChecklist) Done(idx int, msg string) {
+	if !c.markFinished(idx) {
+		return
+	}
+	c.r.Success(c.label(idx, msg))
+}
+
+// Fail in non-TTY mode is silent: callers are expected to return the error to
+// cmd/root.go which emits the user-facing failure line. Suppressing here keeps
+// non-TTY output to one error line per failure.
+//
+// The msg argument is intentionally unused but kept for interface parity with
+// Done/Skip and to match the TTY implementation's signature.
+func (c *nonTTYChecklist) Fail(idx int, msg string) {
+	_ = msg
+	c.markFinished(idx)
+}
+
+// Skip in non-TTY mode emits an Info line, distinguishing the early-exit
+// branch (e.g. "no changes detected") from a successful completion.
+func (c *nonTTYChecklist) Skip(idx int, msg string) {
+	if !c.markFinished(idx) {
+		return
+	}
+	c.r.Info(c.label(idx, msg))
+}
+
+func (c *nonTTYChecklist) Close() {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+}
+
+func (c *nonTTYChecklist) markFinished(idx int) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed || idx < 0 || idx >= len(c.items) || c.finished[idx] {
+		return false
+	}
+	c.finished[idx] = true
+	return true
+}
+
+func (c *nonTTYChecklist) label(idx int, msg string) string {
+	if msg != "" {
+		return msg
+	}
+	return c.items[idx].label
+}
+
+// silentChecklist forwards only Fail to Error; Done/Skip/Start are no-ops.
+// Mirrors silentSpinner so fatal failures still surface in scripts using
+// --silent.
+type silentChecklist struct {
+	r        *SilentReporter
+	count    int
+	mu       sync.Mutex
+	finished []bool
+}
+
+func newSilentChecklist(r *SilentReporter, labels []string) *silentChecklist {
+	return &silentChecklist{
+		r:        r,
+		count:    len(labels),
+		finished: make([]bool, len(labels)),
+	}
+}
+
+func (c *silentChecklist) Start(int)        {}
+func (c *silentChecklist) Done(int, string) {}
+func (c *silentChecklist) Skip(int, string) {}
+func (c *silentChecklist) Close()           {}
+
+func (c *silentChecklist) Fail(idx int, msg string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if idx < 0 || idx >= c.count || c.finished[idx] {
+		return
+	}
+	c.finished[idx] = true
+	c.r.Error(msg)
+}
+
+// Compile-time interface checks.
+var (
+	_ reporter.Checklist = (*ttyChecklist)(nil)
+	_ reporter.Checklist = (*nonTTYChecklist)(nil)
+	_ reporter.Checklist = (*silentChecklist)(nil)
+)

--- a/internal/cli/checklist_test.go
+++ b/internal/cli/checklist_test.go
@@ -1,0 +1,260 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/koh-sh/apcdeploy/internal/reporter"
+)
+
+func TestChecklist_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+
+	var (
+		_ reporter.Checklist = (*ttyChecklist)(nil)
+		_ reporter.Checklist = (*nonTTYChecklist)(nil)
+		_ reporter.Checklist = (*silentChecklist)(nil)
+	)
+}
+
+// TestChecklist_NonTTY_OnlyEmitsCompletionLines verifies the contract that in
+// non-TTY mode the checklist stays silent until each item completes — no
+// pre-list, no per-item Start announcement.
+func TestChecklist_NonTTY_OnlyEmitsCompletionLines(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTestReporter()
+	chk := r.Checklist([]string{"phase one", "phase two"})
+
+	chk.Start(0)
+	if errBuf.Len() != 0 {
+		t.Errorf("Start should be silent in non-TTY mode; got %q", errBuf.String())
+	}
+	chk.Done(0, "completed one")
+
+	chk.Start(1)
+	chk.Done(1, "completed two")
+	chk.Close()
+
+	got := errBuf.String()
+	for _, want := range []string{"completed one", "completed two"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected output to contain %q; got %q", want, got)
+		}
+	}
+	// The labels must NOT appear because Start is silent and Done overrides
+	// the label with the completion message.
+	for _, unwanted := range []string{"phase one", "phase two"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("non-TTY checklist must not echo pending labels; got %q", got)
+		}
+	}
+}
+
+// TestChecklist_NonTTY_FailIsSilent verifies the contract that Fail in
+// non-TTY mode emits nothing — root.go's error display covers the failure.
+func TestChecklist_NonTTY_FailIsSilent(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTestReporter()
+	chk := r.Checklist([]string{"phase"})
+
+	chk.Start(0)
+	chk.Fail(0, "ignored message")
+	chk.Close()
+
+	if errBuf.Len() != 0 {
+		t.Errorf("Fail should be silent in non-TTY mode; got %q", errBuf.String())
+	}
+}
+
+// TestChecklist_NonTTY_SkipEmitsInfo verifies that Skip emits an Info line in
+// non-TTY mode so early-exit branches (e.g. "no changes") are still visible.
+func TestChecklist_NonTTY_SkipEmitsInfo(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTestReporter()
+	chk := r.Checklist([]string{"phase"})
+
+	chk.Start(0)
+	chk.Skip(0, "no changes — skipping")
+	chk.Close()
+
+	if !strings.Contains(errBuf.String(), "no changes — skipping") {
+		t.Errorf("expected Skip to emit info line; got %q", errBuf.String())
+	}
+}
+
+// TestChecklist_NonTTY_FallsBackToLabelWhenMessageEmpty verifies that Done
+// with an empty message uses the original item label.
+func TestChecklist_NonTTY_FallsBackToLabelWhenMessageEmpty(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTestReporter()
+	chk := r.Checklist([]string{"label only"})
+	chk.Done(0, "")
+	chk.Close()
+
+	if !strings.Contains(errBuf.String(), "label only") {
+		t.Errorf("expected fallback to label; got %q", errBuf.String())
+	}
+}
+
+// TestChecklist_NonTTY_OutOfRangeIndexIsNoOp ensures invalid indices don't
+// panic or produce output.
+func TestChecklist_NonTTY_OutOfRangeIndexIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTestReporter()
+	chk := r.Checklist([]string{"only one"})
+	chk.Done(5, "should be ignored")
+	chk.Done(-1, "also ignored")
+	chk.Close()
+
+	if errBuf.Len() != 0 {
+		t.Errorf("out-of-range Done should be silent; got %q", errBuf.String())
+	}
+}
+
+// TestChecklist_NonTTY_TransitionAfterCloseIsSilent ensures the Close →
+// transition path is a no-op so deferred Close + accidental Done from a
+// surrounding error path won't double-emit.
+func TestChecklist_NonTTY_TransitionAfterCloseIsSilent(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTestReporter()
+	chk := r.Checklist([]string{"phase"})
+	chk.Close()
+	chk.Done(0, "should be ignored")
+	chk.Skip(0, "should be ignored")
+	chk.Fail(0, "should be ignored")
+
+	if errBuf.Len() != 0 {
+		t.Errorf("transition after Close must be silent; got %q", errBuf.String())
+	}
+}
+
+// TestChecklist_NonTTY_DoubleDoneIsIdempotent ensures repeated transitions on
+// the same item don't double-emit.
+func TestChecklist_NonTTY_DoubleDoneIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTestReporter()
+	chk := r.Checklist([]string{"phase"})
+	chk.Done(0, "first")
+	chk.Done(0, "second")
+	chk.Close()
+
+	if strings.Count(errBuf.String(), "first") != 1 {
+		t.Errorf("expected exactly one 'first' line; got %q", errBuf.String())
+	}
+	if strings.Contains(errBuf.String(), "second") {
+		t.Errorf("expected second Done to be ignored; got %q", errBuf.String())
+	}
+}
+
+// TestChecklist_TTY_RendersInitialPendingBlock verifies the TTY path prints
+// every item up-front so users see the full plan before work starts.
+func TestChecklist_TTY_RendersInitialPendingBlock(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTTYReporter()
+	chk := r.Checklist([]string{"alpha", "beta", "gamma"})
+	chk.Close()
+
+	got := errBuf.String()
+	for _, label := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(got, label) {
+			t.Errorf("expected initial render to contain %q; got %q", label, got)
+		}
+	}
+}
+
+// TestChecklist_TTY_TransitionsRedraw verifies that state changes are
+// reflected in the output. Close synchronizes the animation goroutine via
+// <-c.done plus a final redraw, so we don't need a sleep for the Done message
+// to land in the buffer.
+func TestChecklist_TTY_TransitionsRedraw(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTTYReporter()
+	chk := r.Checklist([]string{"phase"})
+	chk.Start(0)
+	chk.Done(0, "all done")
+	chk.Close()
+
+	if !strings.Contains(errBuf.String(), "all done") {
+		t.Errorf("expected Done message in output; got %q", errBuf.String())
+	}
+}
+
+// TestChecklist_TTY_FailAndSkipRender verifies that Fail and Skip transitions
+// render with their respective messages (visible because the redraw rewrites
+// the line).
+func TestChecklist_TTY_FailAndSkipRender(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTTYReporter()
+	chk := r.Checklist([]string{"a", "b"})
+	chk.Fail(0, "boom")
+	chk.Skip(1, "later")
+	chk.Close()
+
+	got := errBuf.String()
+	if !strings.Contains(got, "boom") {
+		t.Errorf("expected Fail message in TTY output; got %q", got)
+	}
+	if !strings.Contains(got, "later") {
+		t.Errorf("expected Skip message in TTY output; got %q", got)
+	}
+}
+
+// TestChecklist_TTY_DoubleCloseIsIdempotent verifies repeated Close calls are
+// safe — callers commonly defer Close after also explicitly calling it.
+func TestChecklist_TTY_DoubleCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	r, _, _ := newTTYReporter()
+	chk := r.Checklist([]string{"x"})
+	chk.Close()
+	chk.Close() // must not panic or block
+}
+
+// TestSilentReporter_Checklist verifies the silent variant suppresses
+// everything except Fail (which forwards to Error so scripts still see fatal
+// failures).
+func TestSilentReporter_Checklist(t *testing.T) {
+	t.Parallel()
+
+	var errBuf bytes.Buffer
+	r := &SilentReporter{outW: &bytes.Buffer{}, errW: &errBuf}
+	chk := r.Checklist([]string{"a", "b"})
+
+	chk.Start(0)
+	chk.Done(0, "done a")
+	chk.Skip(1, "skipped b")
+	chk.Close()
+
+	if errBuf.Len() != 0 {
+		t.Errorf("silent checklist Start/Done/Skip must be silent; got %q", errBuf.String())
+	}
+
+	chk2 := r.Checklist([]string{"x"})
+	chk2.Fail(0, "boom")
+	if !strings.Contains(errBuf.String(), "boom") {
+		t.Errorf("silent checklist Fail must forward to Error; got %q", errBuf.String())
+	}
+}
+
+// TestSilentReporter_Checklist_OutOfRangeFailIsSafe ensures invalid indices
+// don't panic on the silent variant.
+func TestSilentReporter_Checklist_OutOfRangeFailIsSafe(t *testing.T) {
+	t.Parallel()
+
+	r := &SilentReporter{outW: &bytes.Buffer{}, errW: &bytes.Buffer{}}
+	chk := r.Checklist([]string{"only"})
+	chk.Fail(99, "ignored")
+	chk.Fail(-1, "also ignored")
+	chk.Close()
+}

--- a/internal/cli/reporter.go
+++ b/internal/cli/reporter.go
@@ -124,6 +124,17 @@ func (r *Reporter) Spin(msg string) reporter.Spinner {
 	return newSpinner(r, msg)
 }
 
+// Checklist starts a multi-item progress block. In TTY mode the block updates
+// in place; in non-TTY mode each completed item is emitted as a single
+// Success/Error/Info line on Done/Fail/Skip. The caller MUST eventually
+// invoke Close on the returned Checklist.
+func (r *Reporter) Checklist(items []string) reporter.Checklist {
+	if r.errTTY {
+		return newTTYChecklist(r.errW, items)
+	}
+	return newNonTTYChecklist(r, items)
+}
+
 // Progress starts a percentage-based progress bar. The caller streams updates
 // through ProgressBar.Update and MUST eventually invoke either Done or Fail.
 func (r *Reporter) Progress(msg string) reporter.ProgressBar {

--- a/internal/cli/reporter_test.go
+++ b/internal/cli/reporter_test.go
@@ -95,7 +95,7 @@ func TestReporter_StdoutKinds(t *testing.T) {
 	}
 }
 
-func TestReporter_SpinNonTTY_DoneEmitsSuccess(t *testing.T) {
+func TestReporter_SpinNonTTY_DoneEmitsOnlyCompletion(t *testing.T) {
 	t.Parallel()
 
 	r, _, errBuf := newTestReporter()
@@ -103,8 +103,10 @@ func TestReporter_SpinNonTTY_DoneEmitsSuccess(t *testing.T) {
 	sp.Done("loaded")
 
 	got := errBuf.String()
-	if !strings.Contains(got, "loading") {
-		t.Errorf("Spin should emit a Step line in non-TTY mode; got %q", got)
+	// In non-TTY mode the start message must be silent so logs only carry
+	// terminal states; only the Done message should appear.
+	if strings.Contains(got, "loading") {
+		t.Errorf("Spin should not emit the start message in non-TTY mode; got %q", got)
 	}
 	if !strings.Contains(got, "loaded") {
 		t.Errorf("Spinner.Done should emit a Success line; got %q", got)
@@ -121,6 +123,26 @@ func TestReporter_SpinNonTTY_FailEmitsError(t *testing.T) {
 	got := errBuf.String()
 	if !strings.Contains(got, "oops") {
 		t.Errorf("Spinner.Fail should emit an Error line; got %q", got)
+	}
+}
+
+func TestReporter_SpinNonTTY_StopIsSilentAndIdempotent(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTestReporter()
+	sp := r.Spin("loading")
+	sp.Stop()
+
+	if errBuf.Len() != 0 {
+		t.Errorf("Spinner.Stop must be silent; got %q", errBuf.String())
+	}
+
+	// Done/Fail after Stop must be no-ops so executors that propagate the
+	// error to cmd/root.go don't accidentally double-emit.
+	sp.Done("late done")
+	sp.Fail("late fail")
+	if errBuf.Len() != 0 {
+		t.Errorf("Done/Fail after Stop must be no-ops; got %q", errBuf.String())
 	}
 }
 

--- a/internal/cli/reporter_tty_test.go
+++ b/internal/cli/reporter_tty_test.go
@@ -105,6 +105,28 @@ func TestReporter_SpinTTYFail(t *testing.T) {
 	}
 }
 
+func TestReporter_SpinTTYStopIsSilentAndIdempotent(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTTYReporter()
+	sp := r.Spin("loading")
+	sp.Stop()
+
+	got := errBuf.String()
+	// Stop should clear the spinner line and emit no completion line. Any
+	// frames already drawn are erased by the terminate path's "\r\033[K".
+	if strings.Contains(got, "loaded") || strings.Contains(got, "failed") {
+		t.Errorf("Stop must not emit a completion line; got %q", got)
+	}
+
+	// Subsequent terminations must be no-ops.
+	sp.Done("late")
+	sp.Fail("late")
+	if strings.Contains(errBuf.String(), "late") {
+		t.Errorf("Done/Fail after Stop must be no-ops; got %q", errBuf.String())
+	}
+}
+
 func TestVisibleWidth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/silent_reporter.go
+++ b/internal/cli/silent_reporter.go
@@ -47,6 +47,12 @@ func (r *SilentReporter) Spin(string) reporter.Spinner {
 	return &silentSpinner{r: r}
 }
 
+// Checklist returns a no-op checklist. Done/Skip are silent; only Fail
+// forwards to Error so that fatal failures still surface in scripts.
+func (r *SilentReporter) Checklist(items []string) reporter.Checklist {
+	return newSilentChecklist(r, items)
+}
+
 // Progress returns a no-op progress bar. Done is silent; Fail forwards to
 // Error so that fatal failures still surface in scripts.
 func (r *SilentReporter) Progress(string) reporter.ProgressBar {
@@ -82,6 +88,13 @@ func (s *silentSpinner) Fail(msg string) {
 	}
 	s.finished = true
 	s.r.Error(msg)
+}
+
+func (s *silentSpinner) Stop() {
+	if s.finished {
+		return
+	}
+	s.finished = true
 }
 
 type silentProgressBar struct {

--- a/internal/cli/silent_reporter_test.go
+++ b/internal/cli/silent_reporter_test.go
@@ -105,6 +105,25 @@ func TestSilentReporter_SpinFailEmitsError(t *testing.T) {
 	}
 }
 
+func TestSilentReporter_SpinStopIsSilent(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTestSilentReporter()
+	sp := r.Spin("starting")
+	sp.Stop()
+	if errBuf.Len() != 0 {
+		t.Errorf("silent Spinner.Stop must be silent; got %q", errBuf.String())
+	}
+
+	// Done/Fail after Stop must be no-ops so scripts don't see a stray
+	// Error line via Spinner.Fail.
+	sp.Done("late")
+	sp.Fail("late")
+	if errBuf.Len() != 0 {
+		t.Errorf("Done/Fail after Stop must be no-ops; got %q", errBuf.String())
+	}
+}
+
 func TestSilentReporter_ProgressDoneIsSilent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/spinner.go
+++ b/internal/cli/spinner.go
@@ -10,8 +10,9 @@ import (
 )
 
 // spinner is the concrete reporter.Spinner implementation. In TTY mode it
-// animates bubbles/spinner frames on a goroutine; in non-TTY mode it degrades
-// to a single Step-style line written when the spinner is constructed.
+// animates bubbles/spinner frames on a goroutine; in non-TTY mode it stays
+// silent until Done/Fail emits a single completion line, so logs only carry
+// terminal states (no "starting X..." narration).
 type spinner struct {
 	w        io.Writer
 	tty      bool
@@ -23,7 +24,8 @@ type spinner struct {
 }
 
 // newSpinner constructs a spinner. In TTY mode it kicks off the animation
-// goroutine immediately; in non-TTY mode it writes a single Step line.
+// goroutine immediately; in non-TTY mode it produces no output until the
+// caller invokes Done or Fail.
 func newSpinner(r *Reporter, msg string) *spinner {
 	s := &spinner{
 		w:    r.errW,
@@ -33,8 +35,7 @@ func newSpinner(r *Reporter, msg string) *spinner {
 		r:    r,
 	}
 	if !s.tty {
-		// Non-TTY: emit a Step line and let Done/Fail emit Success/Error.
-		r.Step(msg)
+		// Non-TTY: stay silent; Done/Fail will emit the completion line.
 		close(s.done)
 		return s
 	}
@@ -87,6 +88,15 @@ func (s *spinner) Fail(msg string) {
 	}
 	s.terminate()
 	s.r.Error(msg)
+}
+
+// Stop terminates the spinner without emitting any line. Used when the
+// caller will propagate the error to cmd/root.go for display.
+func (s *spinner) Stop() {
+	if !s.markFinished() {
+		return
+	}
+	s.terminate()
 }
 
 func (s *spinner) markFinished() bool {

--- a/internal/cli/style.go
+++ b/internal/cli/style.go
@@ -6,12 +6,18 @@ import (
 
 // Symbols used as line prefixes by the Reporter. The contract limits visual
 // glyphs to this set — see .claude/rules/output-contract.md.
+//
+// symPending and symSkip are reserved for the multi-item Checklist primitive
+// (pending row and skipped row respectively); the rest are emitted by their
+// corresponding Reporter kinds.
 const (
 	symStep    = "⏳"
 	symSuccess = "✓"
 	symInfo    = "ℹ"
 	symWarn    = "⚠"
 	symError   = "✗"
+	symPending = "○"
+	symSkip    = "→"
 )
 
 // styles holds the lipgloss styles used by the Reporter. Centralizing them

--- a/internal/diff/executor.go
+++ b/internal/diff/executor.go
@@ -38,45 +38,44 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 
 // Execute performs the complete diff workflow
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
-	// Step 1: Load configuration
 	cfg, err := config.LoadConfig(opts.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Step 2: Initialize AWS client
 	awsClient, err := e.clientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS client: %w", err)
 	}
 
-	// Step 3: Resolve resources
-	e.reporter.Step("Resolving resources...")
-	resolver := aws.NewResolver(awsClient)
-	resources, err := resolver.ResolveAll(ctx, cfg.Application, cfg.ConfigurationProfile, cfg.Environment, cfg.DeploymentStrategy)
-	if err != nil {
-		return fmt.Errorf("failed to resolve resources: %w", err)
-	}
-
-	// Step 4: Load local configuration data
 	localData, err := config.LoadDataFile(cfg.DataFile)
 	if err != nil {
 		return fmt.Errorf("failed to load local configuration file: %w", err)
 	}
 
-	// Step 5: Get latest deployment
-	e.reporter.Step("Fetching latest deployment...")
+	// Resolve + GetLatestDeployment + GetHostedConfigurationVersion are folded
+	// into one user-facing phase ("load deployment data") because the user
+	// thinks of them as a single step — fetching the remote side of the diff.
+	sp := e.reporter.Spin("Loading deployment data...")
+	resolver := aws.NewResolver(awsClient)
+	resources, err := resolver.ResolveAll(ctx, cfg.Application, cfg.ConfigurationProfile, cfg.Environment, cfg.DeploymentStrategy)
+	if err != nil {
+		sp.Stop()
+		return fmt.Errorf("failed to resolve resources: %w", err)
+	}
+
 	deployment, err := aws.GetLatestDeployment(ctx, awsClient, resources.ApplicationID, resources.EnvironmentID, resources.Profile.ID)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to get latest deployment: %w", err)
 	}
 
-	// Step 6: Handle case when no deployment exists. Emit the local data as
-	// the stdout payload (acts as the "right side" of the would-be diff) and
-	// surface the next-step hint via the Reporter so silent mode suppresses
-	// the human-facing parts automatically.
+	// No prior deployment: emit the local data as the stdout payload (acts as
+	// the "right side" of the would-be diff) and surface the next-step hint
+	// via the Reporter so silent mode suppresses the human-facing parts
+	// automatically.
 	if deployment == nil {
-		e.reporter.Warn("No deployment found - this will be the initial deployment")
+		sp.Done("No prior deployment — this will be the initial deployment")
 		e.reporter.Header("Local configuration")
 		e.reporter.Data(localData)
 		if len(localData) > 0 && localData[len(localData)-1] != '\n' {
@@ -86,23 +85,20 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 		return nil
 	}
 
-	// Step 7: Get remote configuration
-	e.reporter.Step("Fetching deployed configuration...")
 	remoteData, err := aws.GetHostedConfigurationVersion(ctx, awsClient, resources.ApplicationID, resources.Profile.ID, deployment.ConfigurationVersion)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to get deployed configuration: %w", err)
 	}
+	sp.Done(fmt.Sprintf("Loaded deployment data (deployment #%d, version %s)", deployment.DeploymentNumber, deployment.ConfigurationVersion))
 
-	// Step 8: Calculate diff
 	diffResult, err := calculate(string(remoteData), string(localData), cfg.DataFile, resources.Profile.Type)
 	if err != nil {
 		return fmt.Errorf("failed to calculate diff: %w", err)
 	}
 
-	// Step 9: Display diff (silent mode is handled by the Reporter).
 	display(e.reporter, diffResult, cfg, resources, deployment)
 
-	// Step 10: Return error if differences found and ExitNonzero is set
 	if opts.ExitNonzero && diffResult.HasChanges {
 		return ErrDiffFound
 	}

--- a/internal/diff/executor_test.go
+++ b/internal/diff/executor_test.go
@@ -150,17 +150,18 @@ region: us-east-1
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify warning about no deployment
-	hasWarning := false
+	// "No prior deployment" is now reported as the spinner's Done message
+	// rather than a separate Warn line.
+	hasNotice := false
 	for _, msg := range reporter.Messages {
-		if strings.Contains(msg, "No deployment found") {
-			hasWarning = true
+		if strings.Contains(msg, "No prior deployment") {
+			hasNotice = true
 			break
 		}
 	}
 
-	if !hasWarning {
-		t.Error("expected warning about no deployment")
+	if !hasNotice {
+		t.Errorf("expected 'No prior deployment' notice; got: %v", reporter.Messages)
 	}
 }
 

--- a/internal/edit/workflow.go
+++ b/internal/edit/workflow.go
@@ -109,16 +109,18 @@ func (w *workflow) resolveTargets(ctx context.Context, opts *Options) (*resolved
 		return nil, err
 	}
 
-	w.reporter.Step("Resolving AWS resources...")
+	sp := w.reporter.Spin("Resolving AWS resources...")
 	profile, err := resolver.ResolveConfigurationProfile(ctx, appID, selectedProfile)
 	if err != nil {
+		sp.Stop()
 		return nil, fmt.Errorf("failed to resolve configuration profile: %w", err)
 	}
 	envID, err := resolver.ResolveEnvironment(ctx, appID, selectedEnv)
 	if err != nil {
+		sp.Stop()
 		return nil, fmt.Errorf("failed to resolve environment: %w", err)
 	}
-	w.reporter.Success(fmt.Sprintf("Resolved resources: App=%s, Profile=%s, Env=%s", appID, profile.ID, envID))
+	sp.Done(fmt.Sprintf("Resolved resources: App=%s, Profile=%s, Env=%s", appID, profile.ID, envID))
 
 	return &resolvedTargets{AppID: appID, EnvID: envID, Profile: profile}, nil
 }
@@ -126,29 +128,33 @@ func (w *workflow) resolveTargets(ctx context.Context, opts *Options) (*resolved
 // prepareDeployment fetches the latest deployment, determines the strategy to
 // use, and aborts if another deployment is already in progress.
 //
-// The ongoing-deployment check runs before announcing "Found deployment ..."
+// The ongoing-deployment check runs before announcing "Loaded deployment ..."
 // so users hitting that abort path don't see a misleading success message
 // immediately followed by an error.
 func (w *workflow) prepareDeployment(ctx context.Context, t *resolvedTargets, opts *Options) (*awsInternal.DeployedConfigInfo, string, error) {
-	w.reporter.Step("Checking for ongoing deployments...")
+	sp := w.reporter.Spin("Checking for ongoing deployments...")
 	ongoing, _, err := w.awsClient.CheckOngoingDeployment(ctx, t.AppID, t.EnvID)
 	if err != nil {
+		sp.Stop()
 		return nil, "", fmt.Errorf("failed to check ongoing deployments: %w", err)
 	}
 	if ongoing {
+		sp.Stop()
 		return nil, "", fmt.Errorf("deployment already in progress")
 	}
-	w.reporter.Success("No ongoing deployments")
+	sp.Done("No ongoing deployments")
 
-	w.reporter.Step("Fetching latest deployed configuration...")
+	sp = w.reporter.Spin("Fetching latest deployed configuration...")
 	deployed, err := awsInternal.GetLatestDeployedConfiguration(ctx, w.awsClient, t.AppID, t.EnvID, t.Profile.ID)
 	if err != nil {
+		sp.Stop()
 		return nil, "", fmt.Errorf("failed to get latest deployed configuration: %w", err)
 	}
 	if deployed == nil {
+		sp.Stop()
 		return nil, "", fmt.Errorf("%w: run 'apcdeploy run' to create the first deployment", awsInternal.ErrNoDeployment)
 	}
-	w.reporter.Success(fmt.Sprintf("Found deployment #%d (version %d)", deployed.DeploymentNumber, deployed.VersionNumber))
+	sp.Done(fmt.Sprintf("Loaded deployment #%d (version %d)", deployed.DeploymentNumber, deployed.VersionNumber))
 
 	resolver := awsInternal.NewResolver(w.awsClient)
 	strategyID, err := resolveStrategyID(ctx, resolver, opts.DeploymentStrategy, deployed.DeploymentStrategyID)
@@ -163,43 +169,50 @@ func (w *workflow) prepareDeployment(ctx context.Context, t *resolvedTargets, op
 // configuration version when content changed, and starts the deployment.
 func (w *workflow) editAndDeploy(ctx context.Context, t *resolvedTargets, deployed *awsInternal.DeployedConfigInfo, strategyID string, opts *Options) error {
 	ext := config.ExtensionForContentType(deployed.ContentType)
+
+	// The editor takes over the terminal, so it must NOT be wrapped in a
+	// spinner — the spinner's animation goroutine would conflict with the
+	// editor's own cursor handling. A plain Step line is the right signal
+	// that we're handing off to the editor.
 	w.reporter.Step(fmt.Sprintf("Opening editor (%s)...", editorCommand()))
 	_, edited, err := editBuffer(deployed.Content, ext)
 	if err != nil {
 		return fmt.Errorf("failed to edit configuration: %w", err)
 	}
 
-	w.reporter.Step("Validating configuration data...")
+	// Validation is instant — no spinner. Failure surfaces via the returned
+	// error, which root.go renders.
 	if err := config.ValidateData(edited, deployed.ContentType); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
-	w.reporter.Success("Configuration data validated")
 
 	changed, err := config.HasContentChanged(deployed.Content, edited, ext, t.Profile.Type)
 	if err != nil {
 		return fmt.Errorf("failed to compare configuration: %w", err)
 	}
 	if !changed {
-		w.reporter.Success("No changes detected - skipping deployment")
+		w.reporter.Info("No changes detected — skipping deployment")
 		return nil
 	}
 
-	w.reporter.Step("Creating configuration version...")
+	sp := w.reporter.Spin("Creating configuration version...")
 	versionNumber, err := w.awsClient.CreateHostedConfigurationVersion(ctx, t.AppID, t.Profile.ID, edited, deployed.ContentType, "")
 	if err != nil {
+		sp.Stop()
 		if awsInternal.IsValidationError(err) {
 			return fmt.Errorf("%s", awsInternal.FormatValidationError(err))
 		}
 		return fmt.Errorf("failed to create configuration version: %w", err)
 	}
-	w.reporter.Success(fmt.Sprintf("Created configuration version %d", versionNumber))
+	sp.Done(fmt.Sprintf("Created configuration version %d", versionNumber))
 
-	w.reporter.Step("Starting deployment...")
+	sp = w.reporter.Spin("Starting deployment...")
 	deploymentNumber, err := w.awsClient.StartDeployment(ctx, t.AppID, t.EnvID, t.Profile.ID, strategyID, versionNumber, "")
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to start deployment: %w", err)
 	}
-	w.reporter.Success(fmt.Sprintf("Deployment #%d started", deploymentNumber))
+	sp.Done(fmt.Sprintf("Started deployment #%d", deploymentNumber))
 
 	return w.waitIfRequested(ctx, t.AppID, t.EnvID, deploymentNumber, opts)
 }

--- a/internal/edit/workflow_test.go
+++ b/internal/edit/workflow_test.go
@@ -143,7 +143,7 @@ func TestWorkflowHappyPath(t *testing.T) {
 	}
 
 	assertContainsMessage(t, rep.Messages, "Created configuration version 4")
-	assertContainsMessage(t, rep.Messages, "Deployment #8 started")
+	assertContainsMessage(t, rep.Messages, "Started deployment #8")
 }
 
 func TestWorkflowErrorsWhenNoDeployment(t *testing.T) {

--- a/internal/get/executor.go
+++ b/internal/get/executor.go
@@ -42,35 +42,26 @@ func NewExecutorWithFactory(rep reporter.Reporter, prom prompt.Prompter, factory
 
 // Execute performs the complete configuration retrieval workflow
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
-	// Step 1: Load configuration
-	e.reporter.Step("Loading configuration...")
 	cfg, err := config.LoadConfig(opts.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
-	e.reporter.Success("Configuration loaded")
 
-	// Step 2: Create getter
 	getter, err := e.getterFactory(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create getter: %w", err)
 	}
 
-	// Step 3: Resolve resources
-	e.reporter.Step("Resolving AWS resources...")
+	sp := e.reporter.Spin("Resolving AWS resources...")
 	resolved, err := getter.ResolveResources(ctx)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to resolve resources: %w", err)
 	}
-	e.reporter.Success(fmt.Sprintf("Resolved resources: App=%s, Profile=%s, Env=%s",
-		resolved.ApplicationID,
-		resolved.Profile.ID,
-		resolved.EnvironmentID,
-	))
+	sp.Done(fmt.Sprintf("Resolved resources: App=%s, Profile=%s, Env=%s",
+		resolved.ApplicationID, resolved.Profile.ID, resolved.EnvironmentID))
 
-	// Step 4: Prompt for confirmation unless skipped
 	if !opts.SkipConfirmation {
-		// Check TTY availability before interactive prompt
 		if err := e.prompter.CheckTTY(); err != nil {
 			return fmt.Errorf("%w: use --yes to skip confirmation", err)
 		}
@@ -81,23 +72,21 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 			return fmt.Errorf("failed to get user confirmation: %w", err)
 		}
 
-		// Accept Y, y, Yes, yes
 		normalized := strings.ToLower(strings.TrimSpace(response))
 		if normalized != "y" && normalized != "yes" {
 			return ErrUserDeclined
 		}
 	}
 
-	// Step 5: Get latest configuration
-	e.reporter.Step("Fetching latest configuration...")
+	sp = e.reporter.Spin("Fetching latest configuration...")
 	configData, err := getter.GetConfiguration(ctx, resolved)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to get configuration for profile '%s' in environment '%s': %w",
 			cfg.ConfigurationProfile, cfg.Environment, err)
 	}
-	e.reporter.Success("Configuration retrieved successfully")
+	sp.Done("Fetched configuration")
 
-	// Step 6: Output configuration to stdout
 	e.reporter.Data(configData)
 
 	return nil

--- a/internal/get/executor_test.go
+++ b/internal/get/executor_test.go
@@ -57,13 +57,11 @@ func TestExecutorLoadConfigurationError(t *testing.T) {
 		t.Errorf("expected 'failed to load configuration' error, got: %v", err)
 	}
 
-	// Verify reporter was called for progress
-	if len(reporter.Messages) == 0 {
-		t.Error("expected reporter to have received messages")
-	}
-
-	if !strings.Contains(reporter.Messages[0], "Loading configuration") {
-		t.Errorf("expected first message to be about loading configuration, got: %v", reporter.Messages[0])
+	// Config loading is an instant operation: per the output contract it does
+	// not produce any reporter output on failure — the returned error is the
+	// signal. The reporter should be untouched.
+	if len(reporter.Messages) != 0 {
+		t.Errorf("expected no reporter messages for config-load failure, got: %v", reporter.Messages)
 	}
 }
 
@@ -179,13 +177,13 @@ region: us-east-1
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify all expected messages were reported
+	// Config-load is now an instant operation with no reporter output. The
+	// remaining phases use spinners that emit Step+Done in non-TTY mode.
 	expectedMessages := []string{
-		"Loading configuration",
-		"Configuration loaded",
 		"Resolving AWS resources",
 		"Resolved resources",
 		"Fetching latest configuration",
+		"Fetched configuration",
 	}
 
 	for _, expected := range expectedMessages {

--- a/internal/init/executor_test.go
+++ b/internal/init/executor_test.go
@@ -190,12 +190,12 @@ func TestExecutorFullWorkflowWithMock(t *testing.T) {
 		t.Errorf("data file was not created: %s", dataPath)
 	}
 
-	// Verify all expected messages were reported
+	// init no longer emits a generic "Initializing apcdeploy configuration"
+	// banner; each phase reports its own progress via spinners + Success.
 	expectedMessages := []string{
-		"Initializing apcdeploy configuration",
 		"Resolving AWS resources",
 		"Fetching",
-		"Generating configuration file",
+		"Generated ",
 		"Initialization complete",
 	}
 

--- a/internal/init/initializer.go
+++ b/internal/init/initializer.go
@@ -26,31 +26,27 @@ func New(awsClient *awsInternal.Client, rep reporter.Reporter) *Initializer {
 
 // Run executes the initialization process
 func (i *Initializer) Run(ctx context.Context, opts *Options) (*Result, error) {
-	i.reporter.Step("Initializing apcdeploy configuration...")
+	// The "Initializing apcdeploy configuration" banner is intentionally not
+	// emitted: the user already knows they ran `apcdeploy init`. Each phase
+	// reports its own progress.
 
-	// Resolve AWS resources
 	result, err := i.resolveResources(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	// Fetch configuration version
 	if err := i.fetchConfigVersion(ctx, result); err != nil {
 		return nil, err
 	}
 
-	// Fetch latest deployment strategy
 	i.fetchDeploymentStrategy(ctx, result)
 
-	// Determine data file name
 	i.determineDataFileName(opts, result)
 
-	// Generate files
 	if err := i.generateFiles(opts, result); err != nil {
 		return nil, err
 	}
 
-	// Show next steps (the Reporter handles silent mode for us).
 	i.showNextSteps()
 
 	return result, nil
@@ -58,21 +54,18 @@ func (i *Initializer) Run(ctx context.Context, opts *Options) (*Result, error) {
 
 // resolveResources resolves AWS resources (Application, Profile, Environment)
 func (i *Initializer) resolveResources(ctx context.Context, opts *Options) (*Result, error) {
-	i.reporter.Step("Resolving AWS resources...")
-
+	sp := i.reporter.Spin("Resolving AWS resources...")
 	resolver := awsInternal.NewResolver(i.awsClient)
-
-	// Resolve resources (deployment strategy not needed at this stage)
 	resolved, err := resolver.ResolveAll(ctx, opts.Application, opts.Profile, opts.Environment, "")
 	if err != nil {
+		sp.Stop()
 		return nil, err
 	}
-
-	// Report success
-	i.reporter.Success(fmt.Sprintf("Application: %s (ID: %s)", opts.Application, resolved.ApplicationID))
-	i.reporter.Success(fmt.Sprintf("Configuration Profile: %s (ID: %s)", opts.Profile, resolved.Profile.ID))
-	i.reporter.Success(fmt.Sprintf("Environment: %s (ID: %s)", opts.Environment, resolved.EnvironmentID))
-	i.reporter.Success(fmt.Sprintf("Profile Type: %s", resolved.Profile.Type))
+	// Single-line summary replaces the prior 4-line stack of Success calls.
+	// The detailed IDs are not surfaced because the user just selected these
+	// resources by name and rarely needs to see their AWS IDs.
+	sp.Done(fmt.Sprintf("Resolved resources: App=%s, Profile=%s, Env=%s, Type=%s",
+		opts.Application, opts.Profile, opts.Environment, resolved.Profile.Type))
 
 	return &Result{
 		AppID:       resolved.ApplicationID,
@@ -88,64 +81,58 @@ func (i *Initializer) resolveResources(ctx context.Context, opts *Options) (*Res
 
 // fetchConfigVersion fetches the latest deployed configuration version
 func (i *Initializer) fetchConfigVersion(ctx context.Context, result *Result) error {
-	i.reporter.Step("Fetching latest deployed configuration...")
-
-	// Get latest deployed configuration
+	sp := i.reporter.Spin("Fetching latest deployed configuration...")
 	deployedConfig, err := awsInternal.GetLatestDeployedConfiguration(ctx, i.awsClient, result.AppID, result.EnvID, result.ProfileID)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to get latest deployed configuration: %w", err)
 	}
 
-	// If no deployment exists, we'll create config without data file
 	if deployedConfig == nil {
-		i.reporter.Warn("No deployment found - config file will be created without data")
+		// "No deployment" is reported as the spinner's Done message rather
+		// than a separate Warn so the absence of a prior deployment shows up
+		// inline with the fetch phase.
+		sp.Done("No prior deployment — config file will be created without data")
 		result.DeployedConfig = nil
 		return nil
 	}
 
-	i.reporter.Success(fmt.Sprintf("Found deployment #%d (version %d, ContentType: %s)",
+	sp.Done(fmt.Sprintf("Loaded deployed configuration (deployment #%d, version %d, %s)",
 		deployedConfig.DeploymentNumber,
 		deployedConfig.VersionNumber,
 		deployedConfig.ContentType))
 
 	result.DeployedConfig = deployedConfig
-
 	return nil
 }
 
 // fetchDeploymentStrategy fetches the deployment strategy from the latest deployment
 func (i *Initializer) fetchDeploymentStrategy(ctx context.Context, result *Result) {
-	i.reporter.Step("Fetching latest deployment strategy...")
+	sp := i.reporter.Spin("Fetching latest deployment strategy...")
 
-	// Try to get the latest deployment
 	latestDeployment, err := awsInternal.GetLatestDeployment(ctx, i.awsClient, result.AppID, result.EnvID, result.ProfileID)
 	if err != nil || latestDeployment == nil {
-		// If no deployment found or error, use default strategy
-		i.reporter.Warn("No previous deployments found - using default deployment strategy")
 		result.DeploymentStrategy = config.DefaultDeploymentStrategy
+		sp.Done(fmt.Sprintf("Using default deployment strategy: %s", config.DefaultDeploymentStrategy))
 		return
 	}
 
-	// Get deployment details to retrieve the strategy
 	deploymentDetails, err := awsInternal.GetDeploymentDetails(ctx, i.awsClient, result.AppID, result.EnvID, latestDeployment.DeploymentNumber)
 	if err != nil {
-		i.reporter.Warn("Could not retrieve deployment strategy - using default")
 		result.DeploymentStrategy = config.DefaultDeploymentStrategy
+		sp.Done(fmt.Sprintf("Could not retrieve previous strategy — using default: %s", config.DefaultDeploymentStrategy))
 		return
 	}
 
-	// Resolve the deployment strategy ID to its name
 	resolver := awsInternal.NewResolver(i.awsClient)
 	strategyName, err := resolver.ResolveDeploymentStrategyIDToName(ctx, deploymentDetails.DeploymentStrategyID)
 	if err != nil {
-		// If we can't resolve, use the ID as is (fallback)
-		i.reporter.Warn(fmt.Sprintf("Could not resolve deployment strategy name: %v", err))
+		// Fall back to the raw ID; the user can rename it in apcdeploy.yml.
 		result.DeploymentStrategy = deploymentDetails.DeploymentStrategyID
 	} else {
 		result.DeploymentStrategy = strategyName
 	}
-
-	i.reporter.Success(fmt.Sprintf("Using deployment strategy from latest deployment: %s", result.DeploymentStrategy))
+	sp.Done(fmt.Sprintf("Using deployment strategy from latest deployment: %s", result.DeploymentStrategy))
 }
 
 // determineDataFileName determines the appropriate data file name
@@ -162,26 +149,19 @@ func (i *Initializer) determineDataFileName(opts *Options, result *Result) {
 
 // generateFiles generates the configuration and data files
 func (i *Initializer) generateFiles(opts *Options, result *Result) error {
-	// Generate apcdeploy.yml
-	i.reporter.Step(fmt.Sprintf("Generating configuration file: %s", result.ConfigFile))
-
-	// Use the resolved region from AWS client (which may have been auto-resolved by SDK)
+	// File writes are instant local operations — no spinner needed; a single
+	// Success line per file is the user-facing signal that the file landed.
 	if err := config.GenerateConfigFile(result.AppName, result.ProfileName, result.EnvName, result.DataFile, i.awsClient.Region, result.DeploymentStrategy, result.ConfigFile, opts.Force); err != nil {
 		return fmt.Errorf("failed to generate config file: %w", err)
 	}
+	i.reporter.Success(fmt.Sprintf("Generated %s", result.ConfigFile))
 
-	i.reporter.Success(fmt.Sprintf("Created: %s", result.ConfigFile))
-
-	// Write data file if deployed config exists
 	if result.DeployedConfig != nil {
 		dataFilePath := filepath.Join(filepath.Dir(result.ConfigFile), result.DataFile)
-		i.reporter.Step(fmt.Sprintf("Writing configuration data: %s", dataFilePath))
-
 		if err := config.WriteDataFile(result.DeployedConfig.Content, result.DeployedConfig.ContentType, dataFilePath, result.ProfileType, opts.Force); err != nil {
 			return fmt.Errorf("failed to write data file: %w", err)
 		}
-
-		i.reporter.Success(fmt.Sprintf("Created: %s", dataFilePath))
+		i.reporter.Success(fmt.Sprintf("Wrote %s", dataFilePath))
 	}
 
 	return nil

--- a/internal/init/initializer_test.go
+++ b/internal/init/initializer_test.go
@@ -194,15 +194,17 @@ func TestInitializer_FetchConfigVersion(t *testing.T) {
 				if result.DeployedConfig != nil {
 					t.Error("expected DeployedConfig to be nil")
 				}
-				hasWarning := false
+				// "No deployment" is now reported inline as the spinner's
+				// Done message, not as a separate Warn line.
+				hasNoticeInDone := false
 				for _, msg := range reporter.Messages {
-					if len(msg) > 5 && msg[:5] == "warn:" {
-						hasWarning = true
+					if strings.Contains(msg, "spin-done") && strings.Contains(msg, "No prior deployment") {
+						hasNoticeInDone = true
 						break
 					}
 				}
-				if !hasWarning {
-					t.Error("expected warning message")
+				if !hasNoticeInDone {
+					t.Errorf("expected spin-done with 'No prior deployment'; got: %v", reporter.Messages)
 				}
 			},
 		},
@@ -274,15 +276,17 @@ func TestInitializer_FetchDeploymentStrategy(t *testing.T) {
 			},
 			wantStrategy: "MyCustomStrategy",
 			checkMessages: func(t *testing.T, reporter *reportertest.MockReporter) {
-				hasSuccess := false
+				// Strategy resolution now reports its result via the
+				// spinner's Done message rather than a free-standing Success.
+				hasSpinDone := false
 				for _, msg := range reporter.Messages {
-					if len(msg) > 8 && msg[:8] == "success:" {
-						hasSuccess = true
+					if strings.HasPrefix(msg, "spin-done:") {
+						hasSpinDone = true
 						break
 					}
 				}
-				if !hasSuccess {
-					t.Error("expected success message")
+				if !hasSpinDone {
+					t.Errorf("expected spin-done message; got: %v", reporter.Messages)
 				}
 			},
 		},
@@ -319,15 +323,17 @@ func TestInitializer_FetchDeploymentStrategy(t *testing.T) {
 			},
 			wantStrategy: "AppConfig.AllAtOnce",
 			checkMessages: func(t *testing.T, reporter *reportertest.MockReporter) {
-				hasWarning := false
+				// "No previous deployments — using default" is now the
+				// spinner Done message; the legacy Warn line is gone.
+				hasNoticeInDone := false
 				for _, msg := range reporter.Messages {
-					if len(msg) > 5 && msg[:5] == "warn:" {
-						hasWarning = true
+					if strings.Contains(msg, "spin-done") && strings.Contains(msg, "default") {
+						hasNoticeInDone = true
 						break
 					}
 				}
-				if !hasWarning {
-					t.Error("expected warning message")
+				if !hasNoticeInDone {
+					t.Errorf("expected spin-done with 'default'; got: %v", reporter.Messages)
 				}
 			},
 		},
@@ -513,15 +519,17 @@ func TestInitializer_Run(t *testing.T) {
 				if result.DataFile != "data.json" {
 					t.Errorf("expected DataFile 'data.json', got %q", result.DataFile)
 				}
-				hasProgress := false
+				// Phases now report progress through spinners (spin: + spin-done:)
+				// instead of standalone Step lines.
+				hasSpin := false
 				for _, msg := range reporter.Messages {
-					if len(msg) > 5 && msg[:5] == "step:" {
-						hasProgress = true
+					if strings.HasPrefix(msg, "spin:") {
+						hasSpin = true
 						break
 					}
 				}
-				if !hasProgress {
-					t.Error("expected progress messages")
+				if !hasSpin {
+					t.Errorf("expected spinner progress messages; got: %v", reporter.Messages)
 				}
 			},
 		},
@@ -659,15 +667,16 @@ func TestInitializer_Run(t *testing.T) {
 				if result.DeployedConfig != nil {
 					t.Error("expected DeployedConfig to be nil")
 				}
-				hasWarning := false
+				// "No prior deployment" is now the spinner Done message.
+				hasNoticeInDone := false
 				for _, msg := range reporter.Messages {
-					if len(msg) > 5 && msg[:5] == "warn:" {
-						hasWarning = true
+					if strings.Contains(msg, "spin-done") && strings.Contains(msg, "No prior deployment") {
+						hasNoticeInDone = true
 						break
 					}
 				}
-				if !hasWarning {
-					t.Error("expected warning message about no deployment")
+				if !hasNoticeInDone {
+					t.Errorf("expected spin-done with 'No prior deployment'; got: %v", reporter.Messages)
 				}
 			},
 		},

--- a/internal/init/interactive.go
+++ b/internal/init/interactive.go
@@ -49,25 +49,22 @@ func (s *InteractiveSelector) promptAndReport(promptMsg string, options []string
 
 // SelectRegion prompts user to select a region or returns provided region
 func (s *InteractiveSelector) SelectRegion(ctx context.Context, accountClient awsInternal.AccountAPI, providedRegion string) (string, error) {
-	// Skip prompt if region is provided
 	if providedRegion != "" {
 		return providedRegion, nil
 	}
 
-	s.reporter.Step("Fetching available regions...")
-
-	// List enabled regions
+	sp := s.reporter.Spin("Fetching available regions...")
 	regions, err := awsInternal.ListEnabledRegions(ctx, accountClient)
 	if err != nil {
+		sp.Stop()
 		return "", fmt.Errorf("failed to list regions: %w", err)
 	}
-
-	// Check for empty list
 	if len(regions) == 0 {
+		sp.Stop()
 		return "", errors.New("no enabled regions found in your AWS account")
 	}
+	sp.Done(fmt.Sprintf("Found %d region(s)", len(regions)))
 
-	// Prompt user to select
 	return s.promptAndReport(
 		"Select AWS region:",
 		regions,
@@ -77,20 +74,17 @@ func (s *InteractiveSelector) SelectRegion(ctx context.Context, accountClient aw
 
 // SelectApplication prompts user to select an application or returns provided app
 func (s *InteractiveSelector) SelectApplication(ctx context.Context, client *awsInternal.Client, providedApp string) (string, error) {
-	// Skip prompt if app is provided
 	if providedApp != "" {
 		return providedApp, nil
 	}
 
-	s.reporter.Step("Fetching applications...")
-
-	// List applications
+	sp := s.reporter.Spin("Fetching applications...")
 	applications, err := client.ListAllApplications(ctx)
 	if err != nil {
+		sp.Stop()
 		return "", fmt.Errorf("failed to list applications: %w", err)
 	}
 
-	// Extract and sort names
 	apps := make([]string, 0, len(applications))
 	for _, item := range applications {
 		if item.Name != nil {
@@ -99,12 +93,12 @@ func (s *InteractiveSelector) SelectApplication(ctx context.Context, client *aws
 	}
 
 	if len(apps) == 0 {
+		sp.Stop()
 		return "", errors.New("no applications found. Please create an application in AppConfig first")
 	}
-
 	sort.Strings(apps)
+	sp.Done(fmt.Sprintf("Found %d application(s)", len(apps)))
 
-	// Prompt user to select
 	return s.promptAndReport(
 		"Select application:",
 		apps,
@@ -114,20 +108,17 @@ func (s *InteractiveSelector) SelectApplication(ctx context.Context, client *aws
 
 // SelectConfigurationProfile prompts user to select a profile or returns provided profile
 func (s *InteractiveSelector) SelectConfigurationProfile(ctx context.Context, client *awsInternal.Client, appID string, providedProfile string) (string, error) {
-	// Skip prompt if profile is provided
 	if providedProfile != "" {
 		return providedProfile, nil
 	}
 
-	s.reporter.Step("Fetching configuration profiles...")
-
-	// List profiles
+	sp := s.reporter.Spin("Fetching configuration profiles...")
 	configProfiles, err := client.ListAllConfigurationProfiles(ctx, appID)
 	if err != nil {
+		sp.Stop()
 		return "", fmt.Errorf("failed to list configuration profiles: %w", err)
 	}
 
-	// Extract and sort names
 	profiles := make([]string, 0, len(configProfiles))
 	for _, item := range configProfiles {
 		if item.Name != nil {
@@ -136,12 +127,12 @@ func (s *InteractiveSelector) SelectConfigurationProfile(ctx context.Context, cl
 	}
 
 	if len(profiles) == 0 {
+		sp.Stop()
 		return "", errors.New("no configuration profiles found. Please create a configuration profile in AppConfig first")
 	}
-
 	sort.Strings(profiles)
+	sp.Done(fmt.Sprintf("Found %d configuration profile(s)", len(profiles)))
 
-	// Prompt user to select
 	return s.promptAndReport(
 		"Select configuration profile:",
 		profiles,
@@ -151,20 +142,17 @@ func (s *InteractiveSelector) SelectConfigurationProfile(ctx context.Context, cl
 
 // SelectEnvironment prompts user to select an environment or returns provided env
 func (s *InteractiveSelector) SelectEnvironment(ctx context.Context, client *awsInternal.Client, appID string, providedEnv string) (string, error) {
-	// Skip prompt if env is provided
 	if providedEnv != "" {
 		return providedEnv, nil
 	}
 
-	s.reporter.Step("Fetching environments...")
-
-	// List environments
+	sp := s.reporter.Spin("Fetching environments...")
 	environments, err := client.ListAllEnvironments(ctx, appID)
 	if err != nil {
+		sp.Stop()
 		return "", fmt.Errorf("failed to list environments: %w", err)
 	}
 
-	// Extract and sort names
 	envs := make([]string, 0, len(environments))
 	for _, item := range environments {
 		if item.Name != nil {
@@ -173,12 +161,12 @@ func (s *InteractiveSelector) SelectEnvironment(ctx context.Context, client *aws
 	}
 
 	if len(envs) == 0 {
+		sp.Stop()
 		return "", errors.New("no environments found. Please create an environment in AppConfig first")
 	}
-
 	sort.Strings(envs)
+	sp.Done(fmt.Sprintf("Found %d environment(s)", len(envs)))
 
-	// Prompt user to select
 	return s.promptAndReport(
 		"Select environment:",
 		envs,

--- a/internal/lsresources/executor.go
+++ b/internal/lsresources/executor.go
@@ -40,28 +40,21 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory ClientFactory) *Execu
 // in normal mode the tree is rendered through Reporter.Header / Reporter.Table
 // (stderr, suppressed under --silent).
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
-	// Step 1: Create AWS client (with or without explicit region)
-	e.reporter.Step("Creating AWS client...")
 	client, err := e.clientFactory(ctx, opts.Region)
 	if err != nil {
 		return fmt.Errorf("failed to create AWS client: %w", err)
 	}
-	e.reporter.Success("AWS client created")
-
-	// Get the actual region used (either provided or SDK default)
 	region := client.Region
-	e.reporter.Step(fmt.Sprintf("Using region: %s", region))
 
-	// Step 2: List resources
-	e.reporter.Step("Fetching AppConfig resources...")
+	sp := e.reporter.Spin(fmt.Sprintf("Fetching AppConfig resources (%s)...", region))
 	lister := New(client, region)
 	tree, err := lister.ListResources(ctx)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to list resources: %w", err)
 	}
-	e.reporter.Success(fmt.Sprintf("Found %d application(s)", len(tree.Applications)))
+	sp.Done(fmt.Sprintf("Found %d application(s) in %s", len(tree.Applications), region))
 
-	// Step 3: Format and emit results
 	if opts.JSON {
 		payload, err := FormatJSON(tree, opts.ShowStrategies)
 		if err != nil {

--- a/internal/pull/executor.go
+++ b/internal/pull/executor.go
@@ -35,93 +35,74 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 
 // Execute performs the complete pull workflow
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
-	// Step 1: Load configuration
-	e.reporter.Step("Loading configuration...")
 	cfg, err := config.LoadConfig(opts.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
-	e.reporter.Success("Configuration loaded")
 
-	// Step 2: Initialize AWS client
 	awsClient, err := e.clientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS client: %w", err)
 	}
 
-	// Step 3: Resolve resources
-	e.reporter.Step("Resolving resources...")
+	const (
+		phaseLoad   = 0
+		phaseUpdate = 1
+	)
+	chk := e.reporter.Checklist([]string{
+		"Loading deployment data",
+		"Updating data file",
+	})
+	defer chk.Close()
+
+	chk.Start(phaseLoad)
 	resolver := aws.NewResolver(awsClient)
-	// Deployment strategy not needed for pull operation
 	resources, err := resolver.ResolveAll(ctx, cfg.Application, cfg.ConfigurationProfile, cfg.Environment, "")
 	if err != nil {
+		chk.Fail(phaseLoad, "")
 		return fmt.Errorf("failed to resolve resources: %w", err)
 	}
-	e.reporter.Success(fmt.Sprintf("Resolved resources: App=%s, Profile=%s, Env=%s",
-		resources.ApplicationID,
-		resources.Profile.ID,
-		resources.EnvironmentID,
-	))
 
-	// Step 4: Get latest deployed configuration
-	e.reporter.Step("Fetching latest deployed configuration...")
 	deployedConfig, err := aws.GetLatestDeployedConfiguration(ctx, awsClient, resources.ApplicationID, resources.EnvironmentID, resources.Profile.ID)
 	if err != nil {
+		chk.Fail(phaseLoad, "")
 		return fmt.Errorf("failed to get latest deployed configuration: %w", err)
 	}
-
-	// Handle case when no deployment exists
 	if deployedConfig == nil {
+		chk.Fail(phaseLoad, "")
 		return fmt.Errorf("%w: run 'apcdeploy run' to create the first deployment", aws.ErrNoDeployment)
 	}
+	chk.Done(phaseLoad, fmt.Sprintf("Loaded deployment data (deployment #%d, version %d)",
+		deployedConfig.DeploymentNumber, deployedConfig.VersionNumber))
 
-	e.reporter.Success(fmt.Sprintf("Found deployment #%d (version %d)",
-		deployedConfig.DeploymentNumber,
-		deployedConfig.VersionNumber,
-	))
-
-	// Step 5: Check for changes between local and remote
-	e.reporter.Step("Checking for changes...")
-
-	// Determine the full path to the data file
+	chk.Start(phaseUpdate)
 	dataFilePath := cfg.DataFile
 	if !filepath.IsAbs(dataFilePath) {
-		configDir := filepath.Dir(opts.ConfigFile)
-		dataFilePath = filepath.Join(configDir, cfg.DataFile)
+		dataFilePath = filepath.Join(filepath.Dir(opts.ConfigFile), cfg.DataFile)
 	}
 
-	// Load current local data file
-	localData, err := config.LoadDataFile(dataFilePath)
-	if err != nil {
-		// If file doesn't exist or can't be read, proceed with update
-		e.reporter.Warn(fmt.Sprintf("Could not read local data file: %v", err))
-	} else {
-		// Compare local and remote content after normalization
+	// Compare against the existing local file (if any) so a no-op pull skips
+	// the write — pull is idempotent and should not touch mtimes when nothing
+	// changed. A read error is treated as "file missing" and falls through to
+	// the write path.
+	if localData, readErr := config.LoadDataFile(dataFilePath); readErr == nil {
 		ext := filepath.Ext(dataFilePath)
 		hasChanges, err := config.HasContentChanged(localData, deployedConfig.Content, ext, resources.Profile.Type)
 		if err != nil {
+			chk.Fail(phaseUpdate, "")
 			return fmt.Errorf("failed to check for changes: %w", err)
 		}
-
 		if !hasChanges {
-			e.reporter.Success("No changes detected - local data file is already up to date")
-			e.reporter.Success(fmt.Sprintf("Local file matches deployment #%d", deployedConfig.DeploymentNumber))
+			chk.Skip(phaseUpdate, fmt.Sprintf("Local file matches deployment #%d", deployedConfig.DeploymentNumber))
 			return nil
 		}
-
-		e.reporter.Success("Changes detected")
 	}
 
-	// Step 6: Update data file
-	e.reporter.Step("Updating data file...")
-
-	// Write data file (force=true to overwrite existing file)
 	if err := config.WriteDataFile(deployedConfig.Content, deployedConfig.ContentType, dataFilePath, resources.Profile.Type, true); err != nil {
+		chk.Fail(phaseUpdate, "")
 		return fmt.Errorf("failed to write data file: %w", err)
 	}
-
-	e.reporter.Success(fmt.Sprintf("Data file updated: %s", dataFilePath))
-	e.reporter.Success(fmt.Sprintf("Successfully pulled configuration from deployment #%d", deployedConfig.DeploymentNumber))
+	chk.Done(phaseUpdate, fmt.Sprintf("Updated %s", dataFilePath))
 
 	return nil
 }

--- a/internal/pull/executor_test.go
+++ b/internal/pull/executor_test.go
@@ -178,12 +178,12 @@ region: us-east-1
 		t.Errorf("expected data file to contain new value, got: %s", string(updatedData))
 	}
 
-	// Verify all expected messages were reported
+	// Pull now reports progress via a 2-item Checklist (load + update). Each
+	// item should fire exactly one Done transition in the happy path.
 	expectedMessages := []string{
-		"Loading configuration",
-		"Resolving resources",
-		"Fetching latest deployed configuration",
-		"Updating data file",
+		"checklist: Loading deployment data,Updating data file",
+		"Loaded deployment data",
+		"Updated ",
 	}
 
 	for _, expected := range expectedMessages {
@@ -656,16 +656,17 @@ region: us-east-1
 		t.Error("expected data file to NOT be modified when no changes exist")
 	}
 
-	// Verify "no changes" message was reported
-	foundNoChanges := false
+	// The no-change branch finalizes the update phase via Skip with the
+	// "Local file matches deployment #N" message.
+	foundSkip := false
 	for _, msg := range reporter.Messages {
-		if strings.Contains(msg, "No changes") || strings.Contains(msg, "already up to date") {
-			foundNoChanges = true
+		if strings.Contains(msg, "checklist-skip") && strings.Contains(msg, "Local file matches deployment") {
+			foundSkip = true
 			break
 		}
 	}
-	if !foundNoChanges {
-		t.Errorf("expected 'no changes' message in reporter output, got: %v", reporter.Messages)
+	if !foundSkip {
+		t.Errorf("expected checklist-skip with 'Local file matches deployment' message; got: %v", reporter.Messages)
 	}
 }
 

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -10,8 +10,8 @@ package reporter
 // not call fmt.Fprint* directly; everything flows through this interface.
 //
 // Channel and silent-mode behavior are fixed per kind:
-//   - Step / Success / Info / Warn / Header / Box / Table / Spin → stderr,
-//     suppressed in silent mode.
+//   - Step / Success / Info / Warn / Header / Box / Table / Spin / Checklist
+//     → stderr, suppressed in silent mode.
 //   - Error → stderr, always shown.
 //   - Data / Diff → stdout, always shown.
 type Reporter interface {
@@ -36,9 +36,17 @@ type Reporter interface {
 
 	// Spin starts an animated indicator wrapping a long-running call. The
 	// caller MUST eventually invoke either Done or Fail on the returned
-	// Spinner. On non-TTY output, Spin emits a Step line and the spinner is
-	// a no-op until Done/Fail.
+	// Spinner. On non-TTY output, Spin is silent until Done/Fail emits a
+	// completion line — there is no leading Step announcement.
 	Spin(msg string) Spinner
+
+	// Checklist starts a multi-item progress block. items defines the labels
+	// shown initially as pending (○). The caller drives transitions via the
+	// returned Checklist handle, then closes it. In TTY mode the block updates
+	// in place (active item shows an animated spinner); in non-TTY mode only
+	// the completion line for each item is emitted (no pre-list, no Step).
+	// Use Spin instead when the work has only a single phase.
+	Checklist(items []string) Checklist
 
 	// Progress starts a percentage-based progress indicator. In TTY mode it
 	// renders a live bar that the caller updates via ProgressBar.Update; in
@@ -55,12 +63,48 @@ type Reporter interface {
 }
 
 // Spinner is the handle returned by Reporter.Spin. Callers MUST call exactly
-// one of Done or Fail to terminate the spinner.
+// one of Done, Fail, or Stop to terminate the spinner.
 type Spinner interface {
 	// Done stops the spinner and reports a success line with the given message.
 	Done(msg string)
 	// Fail stops the spinner and reports an error line with the given message.
+	// Use Stop instead when the caller will propagate the error and rely on
+	// cmd/root.go to format it, so the user sees a single error line.
 	Fail(msg string)
+	// Stop terminates the spinner without emitting any line. Use when the
+	// caller is about to return an error that will be reported by the
+	// top-level error handler.
+	Stop()
+}
+
+// Checklist is the handle returned by Reporter.Checklist. Items are referenced
+// by their zero-based index in the slice passed to Checklist. Each item moves
+// through the states: pending (○) → active (⠋) → done (✓) / fail (✗) / skip
+// (→). Callers MUST call Close exactly once to release any background
+// rendering goroutine; Close is idempotent.
+//
+// Items left in pending or active state when Close is called are finalized as
+// pending (○). For deterministic output, finish or skip every item explicitly
+// before Close.
+type Checklist interface {
+	// Start marks the item as in-progress (animated spinner in TTY mode).
+	// Calling Start on the same index twice is a no-op.
+	Start(idx int)
+	// Done marks the item as successfully completed; msg replaces the label
+	// when non-empty.
+	Done(idx int, msg string)
+	// Fail marks the item as failed; msg replaces the label when non-empty.
+	// In TTY mode the item renders with ✗. In non-TTY mode Fail is silent —
+	// the caller is expected to return an error that cmd/root.go formats, so
+	// the user sees a single error line. The silent Reporter forwards Fail to
+	// Error so that fatal failures still surface in scripts.
+	Fail(idx int, msg string)
+	// Skip marks the item as skipped (e.g. an early-exit branch); msg
+	// replaces the label when non-empty.
+	Skip(idx int, msg string)
+	// Close finalizes the checklist. After Close, further Start/Done/Fail/Skip
+	// calls are no-ops.
+	Close()
 }
 
 // ProgressBar is the handle returned by Reporter.Progress. Callers stream

--- a/internal/reporter/testing/mock.go
+++ b/internal/reporter/testing/mock.go
@@ -28,6 +28,24 @@ type MockReporter struct {
 	// ProgressCalls records each progress-bar lifecycle: the start message,
 	// every Update call, and the terminating Done/Fail message.
 	ProgressCalls []ProgressCall
+
+	// ChecklistCalls records each checklist lifecycle: the initial item
+	// labels and every state transition.
+	ChecklistCalls []ChecklistCall
+}
+
+// ChecklistCall captures the lifecycle of a single Checklist invocation.
+type ChecklistCall struct {
+	Items       []string
+	Transitions []ChecklistTransition
+	Closed      bool
+}
+
+// ChecklistTransition records one Start/Done/Fail/Skip call on a checklist.
+type ChecklistTransition struct {
+	Index   int
+	Outcome string // "start", "done", "fail", "skip"
+	Message string
 }
 
 // ProgressCall captures the lifecycle of a single progress bar.
@@ -107,6 +125,15 @@ func (m *MockReporter) Progress(msg string) reporter.ProgressBar {
 	return &mockProgressBar{m: m, idx: idx}
 }
 
+func (m *MockReporter) Checklist(items []string) reporter.Checklist {
+	idx := len(m.ChecklistCalls)
+	m.ChecklistCalls = append(m.ChecklistCalls, ChecklistCall{
+		Items: append([]string(nil), items...),
+	})
+	m.Messages = append(m.Messages, "checklist: "+strings.Join(items, ","))
+	return &mockChecklist{m: m, idx: idx}
+}
+
 func (m *MockReporter) Data(p []byte) {
 	m.Stdout = append(m.Stdout, p...)
 	m.Messages = append(m.Messages, "data: "+string(p))
@@ -135,6 +162,7 @@ func (m *MockReporter) Clear() {
 	m.Boxes = nil
 	m.SpinnerCalls = nil
 	m.ProgressCalls = nil
+	m.ChecklistCalls = nil
 }
 
 type mockSpinner struct {
@@ -161,6 +189,15 @@ func (s *mockSpinner) Fail(msg string) {
 	s.m.SpinnerCalls[s.idx].Outcome = "fail"
 	s.m.SpinnerCalls[s.idx].EndMessage = msg
 	s.m.Messages = append(s.m.Messages, "spin-fail: "+msg)
+}
+
+func (s *mockSpinner) Stop() {
+	if s.finished {
+		return
+	}
+	s.finished = true
+	s.m.SpinnerCalls[s.idx].Outcome = "stop"
+	s.m.Messages = append(s.m.Messages, "spin-stop")
 }
 
 type mockProgressBar struct {
@@ -206,4 +243,38 @@ func (p *mockProgressBar) Stop() {
 	p.finished = true
 	p.m.ProgressCalls[p.idx].Outcome = "stop"
 	p.m.Messages = append(p.m.Messages, "progress-stop")
+}
+
+type mockChecklist struct {
+	m      *MockReporter
+	idx    int
+	closed bool
+}
+
+func (c *mockChecklist) Start(idx int)            { c.record(idx, "start", "") }
+func (c *mockChecklist) Done(idx int, msg string) { c.record(idx, "done", msg) }
+func (c *mockChecklist) Fail(idx int, msg string) { c.record(idx, "fail", msg) }
+func (c *mockChecklist) Skip(idx int, msg string) { c.record(idx, "skip", msg) }
+
+func (c *mockChecklist) Close() {
+	if c.closed {
+		return
+	}
+	c.closed = true
+	c.m.ChecklistCalls[c.idx].Closed = true
+	c.m.Messages = append(c.m.Messages, "checklist-close")
+}
+
+func (c *mockChecklist) record(idx int, outcome, msg string) {
+	if c.closed {
+		return
+	}
+	c.m.ChecklistCalls[c.idx].Transitions = append(c.m.ChecklistCalls[c.idx].Transitions,
+		ChecklistTransition{Index: idx, Outcome: outcome, Message: msg})
+	tag := "checklist-" + outcome
+	if msg != "" {
+		c.m.Messages = append(c.m.Messages, tag+": "+msg)
+	} else {
+		c.m.Messages = append(c.m.Messages, tag)
+	}
 }

--- a/internal/reporter/testing/mock_test.go
+++ b/internal/reporter/testing/mock_test.go
@@ -167,6 +167,78 @@ func TestMockReporter_ProgressLifecycle(t *testing.T) {
 	})
 }
 
+func TestMockReporter_ChecklistLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("records all transitions and Close", func(t *testing.T) {
+		t.Parallel()
+		m := &MockReporter{}
+		chk := m.Checklist([]string{"alpha", "beta", "gamma"})
+
+		chk.Start(0)
+		chk.Done(0, "alpha-done")
+		chk.Skip(1, "beta-skipped")
+		chk.Fail(2, "gamma-failed")
+		chk.Close()
+
+		if len(m.ChecklistCalls) != 1 {
+			t.Fatalf("expected 1 checklist call; got %d", len(m.ChecklistCalls))
+		}
+		got := m.ChecklistCalls[0]
+		if !got.Closed {
+			t.Error("expected Closed=true after Close()")
+		}
+		wantLabels := []string{"alpha", "beta", "gamma"}
+		for i, l := range wantLabels {
+			if got.Items[i] != l {
+				t.Errorf("Items[%d] = %q, want %q", i, got.Items[i], l)
+			}
+		}
+		// Start, Done(0), Skip(1), Fail(2) — 4 transitions in order.
+		if len(got.Transitions) != 4 {
+			t.Fatalf("expected 4 transitions; got %d (%+v)", len(got.Transitions), got.Transitions)
+		}
+		want := []ChecklistTransition{
+			{Index: 0, Outcome: "start", Message: ""},
+			{Index: 0, Outcome: "done", Message: "alpha-done"},
+			{Index: 1, Outcome: "skip", Message: "beta-skipped"},
+			{Index: 2, Outcome: "fail", Message: "gamma-failed"},
+		}
+		for i, w := range want {
+			if got.Transitions[i] != w {
+				t.Errorf("Transitions[%d] = %+v, want %+v", i, got.Transitions[i], w)
+			}
+		}
+	})
+
+	t.Run("double Close is no-op", func(t *testing.T) {
+		t.Parallel()
+		m := &MockReporter{}
+		chk := m.Checklist([]string{"x"})
+		chk.Close()
+		closeMessages := len(m.Messages)
+		chk.Close()
+		if len(m.Messages) != closeMessages {
+			t.Errorf("second Close must not append a message; got %v", m.Messages)
+		}
+	})
+
+	t.Run("transitions after Close are silent", func(t *testing.T) {
+		t.Parallel()
+		m := &MockReporter{}
+		chk := m.Checklist([]string{"x"})
+		chk.Close()
+		chk.Start(0)
+		chk.Done(0, "ignored")
+		chk.Fail(0, "ignored")
+		chk.Skip(0, "ignored")
+		// Only "checklist:" + "checklist-close" should be present.
+		if len(m.ChecklistCalls[0].Transitions) != 0 {
+			t.Errorf("post-Close transitions must be ignored; got %+v", m.ChecklistCalls[0].Transitions)
+		}
+	})
+}
+
 func TestMockReporter_HasMessage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/rollback/executor.go
+++ b/internal/rollback/executor.go
@@ -47,54 +47,51 @@ func NewExecutorWithFactory(rep reporter.Reporter, prom prompt.Prompter, factory
 
 // Execute performs the rollback workflow
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
-	// Step 1: Load configuration
 	cfg, err := config.LoadConfig(opts.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Step 2: Initialize AWS client
 	awsClient, err := e.clientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS client: %w", err)
 	}
 
-	// Step 3: Resolve resources
-	e.reporter.Step("Resolving resources...")
+	// The discovery phase ("find a deployment to roll back") spans resolve +
+	// CheckOngoing + GetDeploymentDetails. They share a single user-facing
+	// step; the actual stop happens after the confirmation prompt as a
+	// separate spinner so the user sees a clear "we acted" line.
+	sp := e.reporter.Spin("Finding ongoing deployment...")
 	resolver := aws.NewResolver(awsClient)
 	resources, err := resolver.ResolveAll(ctx, cfg.Application, cfg.ConfigurationProfile, cfg.Environment, cfg.DeploymentStrategy)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to resolve resources: %w", err)
 	}
 
-	// Step 4: Find ongoing deployment
-	e.reporter.Step("Checking for ongoing deployment...")
 	hasOngoing, deployment, err := awsClient.CheckOngoingDeployment(ctx, resources.ApplicationID, resources.EnvironmentID)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to check ongoing deployment: %w", err)
 	}
-
 	if !hasOngoing || deployment == nil {
+		sp.Stop()
 		return ErrNoOngoingDeployment
 	}
 
 	deploymentNumber := deployment.DeploymentNumber
-	e.reporter.Success(fmt.Sprintf("Found ongoing deployment #%d", deploymentNumber))
-
-	// Step 5: Get deployment details for confirmation
 	details, err := aws.GetDeploymentDetails(ctx, awsClient, resources.ApplicationID, resources.EnvironmentID, deploymentNumber)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to get deployment details: %w", err)
 	}
+	sp.Done(fmt.Sprintf("Found ongoing deployment #%d (%s)", deploymentNumber, details.State))
 
-	// Step 6: Prompt for confirmation unless skipped
 	if !opts.SkipConfirmation {
-		// Check TTY availability before interactive prompt
 		if err := e.prompter.CheckTTY(); err != nil {
 			return fmt.Errorf("use --yes to skip confirmation: %w", err)
 		}
 
-		// Show deployment information (silent mode is handled by the Reporter).
 		display.DeploymentStatus(e.reporter, details, cfg, resources)
 
 		message := fmt.Sprintf("Stop deployment #%d? This will rollback the deployment. (Y/Yes)", deploymentNumber)
@@ -103,20 +100,18 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 			return fmt.Errorf("failed to get user confirmation: %w", err)
 		}
 
-		// Accept Y, y, Yes, yes
 		normalized := strings.ToLower(strings.TrimSpace(response))
 		if normalized != "y" && normalized != "yes" {
 			return ErrUserDeclined
 		}
 	}
 
-	// Step 7: Stop deployment
-	e.reporter.Step(fmt.Sprintf("Stopping deployment #%d...", deploymentNumber))
+	sp = e.reporter.Spin(fmt.Sprintf("Stopping deployment #%d...", deploymentNumber))
 	if err := awsClient.StopDeployment(ctx, resources.ApplicationID, resources.EnvironmentID, deploymentNumber); err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to stop deployment: %w", err)
 	}
-
-	e.reporter.Success(fmt.Sprintf("Deployment #%d stopped successfully", deploymentNumber))
+	sp.Done(fmt.Sprintf("Stopped deployment #%d", deploymentNumber))
 
 	return nil
 }

--- a/internal/run/executor.go
+++ b/internal/run/executor.go
@@ -34,103 +34,119 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 
 // Execute performs the complete deployment workflow
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
-	// Validate timeout
 	if opts.Timeout < 0 {
 		return fmt.Errorf("timeout must be a non-negative value")
 	}
-
-	// Validate wait flags: both cannot be specified together
 	if opts.WaitDeploy && opts.WaitBake {
 		return fmt.Errorf("--wait-deploy and --wait-bake cannot be used together")
 	}
 
-	// Step 1: Load configuration
-	e.reporter.Step("Loading configuration...")
 	cfg, dataContent, err := loadConfiguration(opts.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
-	e.reporter.Success("Configuration loaded")
 
-	// Step 2: Create deployer
 	deployer, err := e.deployerFactory(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create deployer: %w", err)
 	}
 
-	// Step 3: Resolve resources
-	e.reporter.Step("Resolving AWS resources...")
+	// Build the checklist plan additively so the conditional "detect changes"
+	// phase doesn't require remapping indices afterward. idxChanges stays -1
+	// when --force skips the AWS round-trip; the only path that touches
+	// idxChanges is gated by !opts.Force, so the sentinel never reaches the
+	// checklist.
+	var labels []string
+	add := func(name string) int {
+		labels = append(labels, name)
+		return len(labels) - 1
+	}
+
+	idxResolve := add("Resolving AWS resources")
+	idxOngoing := add("Checking for ongoing deployments")
+	idxChanges := -1
+	if !opts.Force {
+		idxChanges = add("Detecting changes")
+	}
+	idxVersion := add("Creating configuration version")
+	idxDeploy := add("Starting deployment")
+
+	chk := e.reporter.Checklist(labels)
+	defer chk.Close()
+
+	chk.Start(idxResolve)
 	resolved, err := deployer.ResolveResources(ctx)
 	if err != nil {
+		chk.Fail(idxResolve, "")
 		return fmt.Errorf("failed to resolve resources: %w", err)
 	}
-	e.reporter.Success(fmt.Sprintf("Resolved resources: App=%s, Profile=%s, Env=%s, Strategy=%s",
-		resolved.ApplicationID,
-		resolved.Profile.ID,
-		resolved.EnvironmentID,
-		resolved.DeploymentStrategyID,
-	))
+	chk.Done(idxResolve, fmt.Sprintf("Resolved resources: App=%s, Profile=%s, Env=%s, Strategy=%s",
+		resolved.ApplicationID, resolved.Profile.ID, resolved.EnvironmentID, resolved.DeploymentStrategyID))
 
-	// Step 4: Check for ongoing deployments
-	e.reporter.Step("Checking for ongoing deployments...")
+	chk.Start(idxOngoing)
 	hasOngoingDeployment, _, err := deployer.CheckOngoingDeployment(ctx, resolved)
 	if err != nil {
+		chk.Fail(idxOngoing, "")
 		return fmt.Errorf("failed to check ongoing deployments: %w", err)
 	}
 	if hasOngoingDeployment {
+		chk.Fail(idxOngoing, "")
 		return fmt.Errorf("deployment already in progress")
 	}
-	e.reporter.Success("No ongoing deployments")
+	chk.Done(idxOngoing, "No ongoing deployments")
 
-	// Step 5: Determine content type
 	contentType, err := deployer.DetermineContentType(resolved.Profile.Type, cfg.DataFile)
 	if err != nil {
 		return fmt.Errorf("failed to determine content type: %w", err)
 	}
 
-	// Step 6: Validate local data
-	e.reporter.Step("Validating configuration data...")
+	// Local validation runs without a checklist row: it's instant and
+	// failures surface as the returned error, which root.go renders.
 	if err := deployer.ValidateLocalData(dataContent, contentType); err != nil {
 		return fmt.Errorf("validation failed: %w", err)
 	}
-	e.reporter.Success("Configuration data validated")
 
-	// Step 6.5: Check for differences (unless --force is specified)
 	if !opts.Force {
-		e.reporter.Step("Checking for configuration changes...")
+		chk.Start(idxChanges)
 		hasChanges, err := deployer.HasConfigurationChanges(ctx, resolved, dataContent, cfg.DataFile, contentType)
 		if err != nil {
+			chk.Fail(idxChanges, "")
 			return fmt.Errorf("failed to check for changes: %w", err)
 		}
-
 		if !hasChanges {
-			e.reporter.Success("No changes detected - skipping deployment")
+			chk.Skip(idxChanges, "No changes detected — skipping deployment")
 			return nil
 		}
-		e.reporter.Success("Changes detected - proceeding with deployment")
+		chk.Done(idxChanges, "Detected changes")
 	}
 
-	// Step 7: Create hosted configuration version
-	e.reporter.Step("Creating configuration version...")
+	chk.Start(idxVersion)
 	versionNumber, err := deployer.CreateVersion(ctx, resolved, dataContent, contentType)
 	if err != nil {
-		// Check if this is a validation error and provide user-friendly message
+		chk.Fail(idxVersion, "")
 		if aws.IsValidationError(err) {
 			return fmt.Errorf("%s", aws.FormatValidationError(err))
 		}
 		return fmt.Errorf("failed to create configuration version: %w", err)
 	}
-	e.reporter.Success(fmt.Sprintf("Created configuration version %d", versionNumber))
+	chk.Done(idxVersion, fmt.Sprintf("Created configuration version %d", versionNumber))
 
-	// Step 8: Start deployment
-	e.reporter.Step("Starting deployment...")
+	chk.Start(idxDeploy)
 	deploymentNumber, err := deployer.StartDeployment(ctx, resolved, versionNumber)
 	if err != nil {
+		chk.Fail(idxDeploy, "")
 		return fmt.Errorf("failed to start deployment: %w", err)
 	}
-	e.reporter.Success(fmt.Sprintf("Deployment #%d started", deploymentNumber))
+	chk.Done(idxDeploy, fmt.Sprintf("Started deployment #%d", deploymentNumber))
 
-	// Step 9: Wait for deployment if requested
+	// Supersede the deferred Close above: the wait phase's progress bar
+	// manages its own cursor and would tangle with the checklist's animation
+	// goroutine if both ran concurrently. Close is idempotent, so the deferred
+	// call later becomes a no-op on the success path. The defer remains useful
+	// for the error returns above, where it cleans up before cmd/root.go
+	// renders the error line.
+	chk.Close()
+
 	switch {
 	case opts.WaitDeploy:
 		// Wait for deploy phase only (until BAKING starts)

--- a/internal/run/executor_test.go
+++ b/internal/run/executor_test.go
@@ -131,13 +131,11 @@ func TestExecutorLoadConfigurationError(t *testing.T) {
 		t.Errorf("expected 'failed to load configuration' error, got: %v", err)
 	}
 
-	// Verify reporter was called for progress
-	if len(reporter.Messages) == 0 {
-		t.Error("expected reporter to have received messages")
-	}
-
-	if !strings.Contains(reporter.Messages[0], "Loading configuration") {
-		t.Errorf("expected first message to be about loading configuration, got: %v", reporter.Messages[0])
+	// Config loading is an instant operation: per the output contract it does
+	// not produce any reporter output on failure — the returned error is the
+	// signal. The reporter should be untouched.
+	if len(reporter.Messages) != 0 {
+		t.Errorf("expected no reporter messages for config-load failure, got: %v", reporter.Messages)
 	}
 }
 
@@ -262,20 +260,15 @@ region: us-east-1
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify all expected messages were reported
+	// Run now reports phases through a single Checklist (resolve / ongoing /
+	// detect changes / create version / start deployment) plus a final Warn
+	// when no --wait flag is set.
 	expectedMessages := []string{
-		"Loading configuration",
-		"Configuration loaded",
-		"Resolving AWS resources",
+		"checklist: Resolving AWS resources,Checking for ongoing deployments",
 		"Resolved resources",
-		"Checking for ongoing deployments",
 		"No ongoing deployments",
-		"Validating configuration data",
-		"Configuration data validated",
-		"Creating configuration version",
 		"Created configuration version 1",
-		"Starting deployment",
-		"Deployment #1 started",
+		"Started deployment #1",
 		"Deployment #1 is in progress",
 	}
 
@@ -551,16 +544,19 @@ region: us-east-1
 		t.Error("StartDeployment should not have been called when there are no changes")
 	}
 
-	// Verify success message about no changes
+	// The no-change branch finalizes the changes phase via Skip with the
+	// "No changes detected — skipping deployment" message. Asserting on the
+	// checklist-skip outcome (not just any line containing the text) catches
+	// regressions where the early-exit gets reported as success or warn.
 	found := false
 	for _, msg := range reporter.Messages {
-		if strings.Contains(msg, "No changes detected") || strings.Contains(msg, "no diff") {
+		if strings.Contains(msg, "checklist-skip") && strings.Contains(msg, "No changes detected") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected message about no changes, got messages: %v", reporter.Messages)
+		t.Errorf("expected checklist-skip with 'No changes detected'; got messages: %v", reporter.Messages)
 	}
 }
 
@@ -681,16 +677,18 @@ region: us-east-1
 		t.Error("StartDeployment should have been called with --force flag")
 	}
 
-	// Verify deployment started message
+	// Verify deployment started message — the new wording is
+	// "Started deployment #N" (subject-first, matching the checklist's
+	// imperative-action labels).
 	found := false
 	for _, msg := range reporter.Messages {
-		if strings.Contains(msg, "Deployment #2 started") {
+		if strings.Contains(msg, "Started deployment #2") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected deployment started message, got messages: %v", reporter.Messages)
+		t.Errorf("expected 'Started deployment #2' message, got: %v", reporter.Messages)
 	}
 }
 

--- a/internal/status/executor.go
+++ b/internal/status/executor.go
@@ -36,47 +36,45 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 
 // Execute performs the status check workflow
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
-	// Step 1: Load configuration
 	cfg, err := config.LoadConfig(opts.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Step 2: Initialize AWS client
 	awsClient, err := e.clientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS client: %w", err)
 	}
 
-	// Step 3: Resolve resources
-	e.reporter.Step("Resolving resources...")
+	// Resolve + fetch are folded into a single user-facing phase: from the
+	// caller's perspective this is "look up the deployment" — they don't
+	// distinguish ID resolution from the GetDeployment call.
+	spinMsg := "Fetching latest deployment..."
+	if opts.DeploymentID != "" {
+		spinMsg = fmt.Sprintf("Fetching deployment #%s...", opts.DeploymentID)
+	}
+	sp := e.reporter.Spin(spinMsg)
+
 	resolver := aws.NewResolver(awsClient)
 	resources, err := resolver.ResolveAll(ctx, cfg.Application, cfg.ConfigurationProfile, cfg.Environment, cfg.DeploymentStrategy)
 	if err != nil {
+		sp.Stop()
 		return fmt.Errorf("failed to resolve resources: %w", err)
 	}
 
-	// Step 4: Get deployment information
 	var deploymentInfo *aws.DeploymentDetails
 	if opts.DeploymentID != "" {
-		// Get specific deployment
-		e.reporter.Step(fmt.Sprintf("Fetching deployment #%s...", opts.DeploymentID))
 		deploymentInfo, err = e.getDeploymentByID(ctx, awsClient, resources, opts.DeploymentID)
-		if err != nil {
-			return fmt.Errorf("failed to get deployment: %w", err)
-		}
 	} else {
-		// Get latest deployment
-		e.reporter.Step("Fetching latest deployment...")
 		deploymentInfo, err = e.getLatestDeployment(ctx, awsClient, resources)
-		if err != nil {
-			return fmt.Errorf("failed to get latest deployment: %w", err)
-		}
+	}
+	if err != nil {
+		sp.Stop()
+		return fmt.Errorf("failed to get deployment: %w", err)
 	}
 
-	// Step 5: Display status
 	if deploymentInfo == nil {
-		e.reporter.Warn("No deployments found")
+		sp.Done("No deployments found")
 		e.reporter.Box("Next steps", []string{
 			"No deployments have been created yet for this configuration.",
 			"",
@@ -86,6 +84,7 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 		return nil
 	}
 
+	sp.Done(fmt.Sprintf("Fetched deployment #%d (%s)", deploymentInfo.DeploymentNumber, deploymentInfo.State))
 	display.DeploymentStatus(e.reporter, deploymentInfo, cfg, resources)
 	return nil
 }

--- a/internal/status/executor_test.go
+++ b/internal/status/executor_test.go
@@ -149,16 +149,18 @@ region: us-east-1
 		t.Errorf("expected no error for no deployments case, got: %v", err)
 	}
 
-	// Check that warning was reported
-	foundWarning := false
+	// "No deployments" is now reported as the spinner's Done message rather
+	// than a separate Warn line, so the user sees the result inline with the
+	// fetch-deployment phase.
+	foundCompletion := false
 	for _, msg := range reporter.Messages {
-		if strings.Contains(msg, "warn") && strings.Contains(msg, "No deployments found") {
-			foundWarning = true
+		if strings.Contains(msg, "spin-done") && strings.Contains(msg, "No deployments found") {
+			foundCompletion = true
 			break
 		}
 	}
-	if !foundWarning {
-		t.Error("expected warning message about no deployments")
+	if !foundCompletion {
+		t.Errorf("expected spinner Done with 'No deployments found'; got: %v", reporter.Messages)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a **`Checklist`** Reporter primitive (TTY animated multi-item block, non-TTY completion-only, silent variant) and **`Spinner.Stop()`** so error paths can terminate without double-printing through `cmd/root.go`.
- Redesign every command's output: drop instant-operation Step/Success narration and wrap real AWS calls in `Spin` or `Checklist`. Result: less ""AI prototype""-feeling logs, live progress in terminals, completion-only log lines in CI.
- Update `output-contract.md` + `CLAUDE.md` and adapt the e2e test script to the new spinner Done semantics.

## Output redesign per command

| Command | New shape |
|---|---|
| `lsresources` | 1 Spin (folds client-init + resource fetch) |
| `get` / `status` / `diff` | 1 Spin (resolve + fetch into one user-facing phase) |
| `pull` | Checklist 2 items (Load deployment data / Update file), `Skip` for ""Local file matches deployment #N"" |
| `rollback` | Spin → confirmation prompt → Spin Stop |
| `init` | Spin per phase (no 4-line Success stack; banner removed) |
| `run` | Checklist 4–5 items (--force drops the ""Detecting changes"" phase via additive index builder) + ProgressBar |
| `edit` | Spin × N + interactive editor + Spin × M + ProgressBar |

## Behavior changes (visible to users)

- **TTY**: AWS calls now show an animated spinner (or live multi-item checklist for `run`/`pull`) that resolves to ✓/✗/→ on completion.
- **Non-TTY** (CI / pipes): no more ""starting X..."" Step lines. Only the completion line is emitted, so logs carry only terminal states.
- **Silent (`--silent`)**: unchanged — still suppresses everything except `Error` / `Data` / `Diff`.

## Reporter contract additions

- `Checklist` kind with `Start` / `Done` / `Fail` / `Skip` / `Close` lifecycle (see `output-contract.md`).
- `Spinner.Stop()` for silent termination on error paths (paired with the existing `ProgressBar.Stop()`).
- `Spin()` non-TTY behavior changed: silent until `Done`/`Fail`/`Stop` (was: emitted a Step on construction).
- `symPending` / `symSkip` glyphs added to the contracted symbol set in `internal/cli/style.go`.

## Test plan

- [x] `mise run ci` passes with 90.5% coverage (was 85.5% mid-refactor; recovered with new Checklist + `Spinner.Stop` tests).
- [x] `mise run e2e-run` passes end-to-end against real AWS (S1–S7 + E1–E5).
- [ ] Reviewer: pull this branch, run `./apcdeploy run -c apcdeploy.yml --wait-bake` (or any AWS-touching command) in a real terminal to see the live checklist UI.
- [ ] Reviewer: pipe a command (`./apcdeploy diff | cat`) to verify the non-TTY path emits only completion lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)