### PR TITLE
feat(run,edit): redesign --wait-bake progress UI

### DIFF
--- a/.claude/rules/output-contract.md
+++ b/.claude/rules/output-contract.md
@@ -42,8 +42,12 @@ silent-mode behavior, and visual treatment.
 | `Data(p []byte)` | **stdout** | **always shown** | none | Machine-readable payload |
 | `Diff(p []byte)` | **stdout** | **always shown** | colorized when TTY | Unified diff payload |
 
-`Spinner` is `interface { Done(msg string); Fail(msg string) }`. `Done` emits a
-`Success`-equivalent line; `Fail` emits an `Error`-equivalent line on stderr.
+`Spinner` is `interface { Update(msg string); Done(msg string); Fail(msg
+string); Stop() }`. `Update` swaps the animated label without changing the
+running state — useful for countdown-style mid-flight labels (e.g. "Baking…
+(~5 min left)"); on non-TTY output it is silent. `Done` emits a
+`Success`-equivalent line; `Fail` emits an `Error`-equivalent line on stderr;
+`Stop` terminates silently.
 
 `Checklist` is `interface { Start(idx int); Done(idx int, msg string); Fail(idx
 int, msg string); Skip(idx int, msg string); Close() }`. Items are referenced

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,13 +396,15 @@ Waits until the deployment phase completes (when the deployment enters BAKING st
 Waits for complete deployment including the baking phase:
 - Monitors the full deployment lifecycle: DEPLOYING → BAKING → COMPLETE
 - Returns only when deployment is fully complete
+- Deploy phase renders a progress bar (AppConfig reports a real rollout %); bake phase renders a spinner (no quantified progress — bake is a monitoring wait, not a deployment activity).
+- Both phases show a `(~N min left)` countdown derived from the locally observed elapsed time vs the strategy's `DeploymentDurationInMinutes` / `FinalBakeTimeInMinutes`.
 - Recommended for production deployments requiring full validation
 
 ```bash
 ./apcdeploy run -c apcdeploy.yml --wait-bake
 ```
 
-These flags are mutually exclusive and cannot be used together. Either flag can be combined with `--timeout` to specify maximum wait duration (default: 600 seconds).
+These flags are mutually exclusive and cannot be used together. Either flag can be combined with `--timeout` to specify the total maximum wait duration across both phases (default: 1800 seconds).
 
 ## Go Version and Tools
 

--- a/internal/aws/deployment.go
+++ b/internal/aws/deployment.go
@@ -103,6 +103,18 @@ func (c *Client) StopDeployment(
 	return nil
 }
 
+// rolledBackError formats the error returned when a deployment has reached
+// the ROLLED_BACK state. It pulls the most recent rollback description from
+// the event log when available, falling back to a generic message otherwise.
+// Shared by waitForDeploymentWithCondition and WaitForBakingComplete so the
+// rollback message is consistent across phases.
+func rolledBackError(eventLog []types.DeploymentEvent) error {
+	if reason := ExtractRollbackReason(eventLog); reason != "" {
+		return fmt.Errorf("deployment was rolled back: %s", reason)
+	}
+	return fmt.Errorf("deployment was rolled back")
+}
+
 // ExtractRollbackReason returns the most recent non-empty rollback description
 // from a deployment event log, or "" if none is present.
 func ExtractRollbackReason(eventLog []types.DeploymentEvent) string {
@@ -121,9 +133,12 @@ func ExtractRollbackReason(eventLog []types.DeploymentEvent) string {
 }
 
 // DeploymentTickFunc is invoked on each polling tick of a deployment wait
-// loop, with the current state and percentage-complete reported by AWS.
-// Callers use it to drive live progress UI; nil is allowed.
-type DeploymentTickFunc func(state types.DeploymentState, percent float64)
+// loop, with the current state, percentage-complete reported by AWS, and the
+// configured deployment duration (DeploymentDurationInMinutes converted to a
+// time.Duration). totalDuration is zero when the deployment strategy reports
+// no deploy phase (e.g. AppConfig.AllAtOnce). Callers use it to drive live
+// progress UI and surface remaining-time estimates; nil is allowed.
+type DeploymentTickFunc func(state types.DeploymentState, percent float64, totalDuration time.Duration)
 
 // waitForDeploymentWithCondition is a generic wait function that polls deployment status
 // until the provided checkComplete function returns true or an error occurs
@@ -163,7 +178,8 @@ func (c *Client) waitForDeploymentWithCondition(
 			if output.PercentageComplete != nil {
 				pct = float64(*output.PercentageComplete)
 			}
-			onTick(output.State, pct)
+			totalDuration := time.Duration(output.DeploymentDurationInMinutes) * time.Minute
+			onTick(output.State, pct, totalDuration)
 		}
 
 		// Check deployment state
@@ -177,12 +193,7 @@ func (c *Client) waitForDeploymentWithCondition(
 			return false, nil
 
 		case types.DeploymentStateRolledBack:
-			// Handle rollback state
-			reason := ExtractRollbackReason(output.EventLog)
-			if reason != "" {
-				return false, fmt.Errorf("deployment was rolled back: %s", reason)
-			}
-			return false, fmt.Errorf("deployment was rolled back")
+			return false, rolledBackError(output.EventLog)
 
 		case types.DeploymentStateDeploying:
 			// Still deploying
@@ -243,6 +254,100 @@ func (c *Client) WaitForDeploymentPhase(
 		},
 		onTick,
 	)
+}
+
+// BakeTickFunc is invoked on each polling tick of WaitForBakingComplete with
+// the elapsed time since the wait started locally and the configured bake
+// duration (FinalBakeTimeInMinutes). When total is zero the deployment has
+// no bake window. Callers use it to drive live UI (typically a spinner with
+// a "(~N min left)" countdown label); nil is allowed.
+//
+// Bake is fundamentally a wait, not a quantified rollout — AppConfig does
+// not surface a bake-phase percentage. Callers that want a "% done" feeling
+// can derive elapsed/total themselves, but the canonical UX is a spinner
+// (no bar) since nothing is being deployed during bake.
+type BakeTickFunc func(elapsed, total time.Duration)
+
+// WaitForBakingComplete waits for an in-bake deployment to reach COMPLETE.
+// onTick is invoked on each polling tick with (elapsed, total), where
+// elapsed is the duration since this function was called locally and total
+// is the deployment's FinalBakeTimeInMinutes. AppConfig does not surface a
+// bake-phase percentage of its own, so callers that want a "% done" feeling
+// must derive it from elapsed/total themselves.
+//
+// When the bake duration is zero, onTick is still invoked once on COMPLETE
+// with (0, 0) so the caller can finalize its UI uniformly.
+//
+// The deployment is expected to already be in BAKING (or COMPLETE) state.
+// DEPLOYING or other states are treated as unexpected and yield an error.
+func (c *Client) WaitForBakingComplete(
+	ctx context.Context,
+	applicationID, environmentID string,
+	deploymentNumber int32,
+	timeout time.Duration,
+	onTick BakeTickFunc,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	pollingInterval := c.PollingInterval
+	if pollingInterval == 0 {
+		pollingInterval = 5 * time.Second
+	}
+	ticker := time.NewTicker(pollingInterval)
+	defer ticker.Stop()
+
+	bakeStart := time.Now()
+
+	checkDeployment := func() (bool, error) {
+		input := &appconfig.GetDeploymentInput{
+			ApplicationId:    aws.String(applicationID),
+			EnvironmentId:    aws.String(environmentID),
+			DeploymentNumber: &deploymentNumber,
+		}
+
+		output, err := c.appConfig.GetDeployment(ctx, input)
+		if err != nil {
+			return false, wrapAWSError(err, "failed to get deployment status")
+		}
+
+		bakeDuration := time.Duration(output.FinalBakeTimeInMinutes) * time.Minute
+
+		switch output.State {
+		case types.DeploymentStateComplete:
+			if onTick != nil {
+				onTick(bakeDuration, bakeDuration)
+			}
+			return true, nil
+
+		case types.DeploymentStateBaking:
+			if onTick != nil {
+				onTick(time.Since(bakeStart), bakeDuration)
+			}
+			return false, nil
+
+		case types.DeploymentStateRolledBack:
+			return false, rolledBackError(output.EventLog)
+
+		default:
+			return false, fmt.Errorf("unexpected deployment state during bake wait: %s", output.State)
+		}
+	}
+
+	if complete, err := checkDeployment(); err != nil || complete {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("bake phase timed out after %v", timeout)
+		case <-ticker.C:
+			if complete, err := checkDeployment(); err != nil || complete {
+				return err
+			}
+		}
+	}
 }
 
 // DeploymentInfo contains information about a deployment

--- a/internal/aws/deployment_test.go
+++ b/internal/aws/deployment_test.go
@@ -1064,3 +1064,206 @@ func TestExtractRollbackReason(t *testing.T) {
 		})
 	}
 }
+
+// TestWaitForBakingComplete covers the bake-only wait helper used by run/edit
+// when --wait-bake is set. It verifies state-machine handling (BAKING →
+// COMPLETE / rollback / unexpected state / timeout) and that the bake tick
+// callback receives the configured FinalBakeTimeInMinutes as the total
+// duration, with elapsed advancing across ticks.
+func TestWaitForBakingComplete(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockStates     []types.DeploymentState
+		mockEventLog   []types.DeploymentEvent
+		bakeMinutes    int32
+		timeout        time.Duration
+		wantErr        bool
+		wantErrMsg     string
+		wantTickCalled bool
+	}{
+		{
+			name:           "completes immediately",
+			mockStates:     []types.DeploymentState{types.DeploymentStateComplete},
+			bakeMinutes:    1,
+			timeout:        2 * time.Second,
+			wantTickCalled: true,
+		},
+		{
+			name:           "baking then complete",
+			mockStates:     []types.DeploymentState{types.DeploymentStateBaking, types.DeploymentStateComplete},
+			bakeMinutes:    1,
+			timeout:        2 * time.Second,
+			wantTickCalled: true,
+		},
+		{
+			name:           "zero bake duration still completes",
+			mockStates:     []types.DeploymentState{types.DeploymentStateBaking, types.DeploymentStateComplete},
+			bakeMinutes:    0,
+			timeout:        2 * time.Second,
+			wantTickCalled: true,
+		},
+		{
+			name:         "rolled back during bake surfaces reason",
+			mockStates:   []types.DeploymentState{types.DeploymentStateBaking, types.DeploymentStateRolledBack},
+			mockEventLog: []types.DeploymentEvent{{EventType: types.DeploymentEventTypeRollbackStarted, Description: new("alarm")}},
+			bakeMinutes:  1,
+			timeout:      2 * time.Second,
+			wantErr:      true,
+			wantErrMsg:   "deployment was rolled back: alarm",
+		},
+		{
+			name:        "rolled back without description",
+			mockStates:  []types.DeploymentState{types.DeploymentStateRolledBack},
+			bakeMinutes: 1,
+			timeout:     2 * time.Second,
+			wantErr:     true,
+			wantErrMsg:  "deployment was rolled back",
+		},
+		{
+			name:        "unexpected DEPLOYING state errors out",
+			mockStates:  []types.DeploymentState{types.DeploymentStateDeploying},
+			bakeMinutes: 1,
+			timeout:     2 * time.Second,
+			wantErr:     true,
+			wantErrMsg:  "unexpected deployment state during bake wait",
+		},
+		{
+			name:        "timeout while still baking",
+			mockStates:  []types.DeploymentState{types.DeploymentStateBaking, types.DeploymentStateBaking},
+			bakeMinutes: 1,
+			timeout:     500 * time.Millisecond,
+			wantErr:     true,
+			wantErrMsg:  "bake phase timed out",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callCount := 0
+			mockClient := &mock.MockAppConfigClient{
+				GetDeploymentFunc: func(ctx context.Context, params *appconfig.GetDeploymentInput, optFns ...func(*appconfig.Options)) (*appconfig.GetDeploymentOutput, error) {
+					var state types.DeploymentState
+					if callCount < len(tt.mockStates) {
+						state = tt.mockStates[callCount]
+					} else {
+						state = tt.mockStates[len(tt.mockStates)-1]
+					}
+					callCount++
+					return &appconfig.GetDeploymentOutput{
+						DeploymentNumber:       1,
+						State:                  state,
+						FinalBakeTimeInMinutes: tt.bakeMinutes,
+						EventLog:               tt.mockEventLog,
+					}, nil
+				},
+			}
+
+			client := &Client{
+				appConfig:       mockClient,
+				PollingInterval: 50 * time.Millisecond,
+			}
+
+			var lastElapsed time.Duration
+			var lastTotal time.Duration
+			var ticked bool
+			tick := func(elapsed, total time.Duration) {
+				lastElapsed = elapsed
+				lastTotal = total
+				ticked = true
+			}
+
+			err := client.WaitForBakingComplete(
+				context.Background(),
+				"app-123",
+				"env-123",
+				1,
+				tt.timeout,
+				tick,
+			)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("WaitForBakingComplete() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErrMsg != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("WaitForBakingComplete() error = %q, want contains %q", err.Error(), tt.wantErrMsg)
+				}
+			}
+			if tt.wantTickCalled && !ticked {
+				t.Errorf("expected tick to be invoked at least once")
+			}
+			if tt.wantTickCalled {
+				wantTotal := time.Duration(tt.bakeMinutes) * time.Minute
+				if lastTotal != wantTotal {
+					t.Errorf("final tick total = %v, want %v", lastTotal, wantTotal)
+				}
+				if lastElapsed < 0 {
+					t.Errorf("final tick elapsed = %v, want >= 0", lastElapsed)
+				}
+			}
+		})
+	}
+}
+
+// TestWaitForBakingComplete_TickElapsed verifies that elapsed time
+// monotonically increases across ticks while BAKING, and the final
+// COMPLETE tick reports the full bake duration so callers can render a
+// definitive "done" state.
+func TestWaitForBakingComplete_TickElapsed(t *testing.T) {
+	calls := 0
+	mockClient := &mock.MockAppConfigClient{
+		GetDeploymentFunc: func(ctx context.Context, params *appconfig.GetDeploymentInput, optFns ...func(*appconfig.Options)) (*appconfig.GetDeploymentOutput, error) {
+			calls++
+			state := types.DeploymentStateBaking
+			if calls >= 3 {
+				state = types.DeploymentStateComplete
+			}
+			return &appconfig.GetDeploymentOutput{
+				DeploymentNumber:       1,
+				State:                  state,
+				FinalBakeTimeInMinutes: 60,
+			}, nil
+		},
+	}
+
+	client := &Client{
+		appConfig:       mockClient,
+		PollingInterval: 30 * time.Millisecond,
+	}
+
+	type tickRecord struct {
+		elapsed time.Duration
+		total   time.Duration
+	}
+	var ticks []tickRecord
+	err := client.WaitForBakingComplete(
+		context.Background(),
+		"app-123",
+		"env-123",
+		1,
+		2*time.Second,
+		func(elapsed, total time.Duration) {
+			ticks = append(ticks, tickRecord{elapsed: elapsed, total: total})
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ticks) < 3 {
+		t.Fatalf("expected at least 3 ticks, got %d", len(ticks))
+	}
+	wantTotal := 60 * time.Minute
+	for i, tk := range ticks {
+		if tk.total != wantTotal {
+			t.Errorf("tick %d total = %v, want %v", i, tk.total, wantTotal)
+		}
+	}
+	for i := 1; i < len(ticks); i++ {
+		if ticks[i].elapsed < ticks[i-1].elapsed {
+			t.Errorf("tick %d elapsed = %v not monotonic with previous %v", i, ticks[i].elapsed, ticks[i-1].elapsed)
+		}
+	}
+	if ticks[len(ticks)-1].elapsed != wantTotal {
+		t.Errorf("final tick elapsed = %v, want %v (full bake duration)", ticks[len(ticks)-1].elapsed, wantTotal)
+	}
+}

--- a/internal/cli/reporter_tty_test.go
+++ b/internal/cli/reporter_tty_test.go
@@ -92,6 +92,47 @@ func TestReporter_SpinTTYAnimatesAndCleansUp(t *testing.T) {
 	}
 }
 
+// TestReporter_SpinTTYUpdateChangesLabel asserts that Update mid-flight
+// causes the next animation frame to render the new label, exercising the
+// mu-protected msg field used by countdown labels (e.g. "Baking... (~5
+// min left)").
+func TestReporter_SpinTTYUpdateChangesLabel(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTTYReporter()
+	sp := r.Spin("loading")
+	// Let the spinner render the original label.
+	time.Sleep(150 * time.Millisecond)
+	sp.Update("loading: step 2")
+	// Let it render the new label at least once.
+	time.Sleep(150 * time.Millisecond)
+	sp.Done("loaded")
+
+	got := errBuf.String()
+	if !strings.Contains(got, "loading: step 2") {
+		t.Errorf("expected updated label to be rendered; got %q", got)
+	}
+	if !strings.Contains(got, "loaded") {
+		t.Errorf("expected Done() to print success line; got %q", got)
+	}
+}
+
+// TestReporter_SpinTTYUpdateAfterDoneIsNoOp guards against label
+// corruption when Update races against Done. The mu-protected finished
+// flag ensures Update is silently ignored after termination.
+func TestReporter_SpinTTYUpdateAfterDoneIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	r, _, errBuf := newTTYReporter()
+	sp := r.Spin("loading")
+	sp.Done("loaded")
+	sp.Update("should be ignored")
+
+	if strings.Contains(errBuf.String(), "should be ignored") {
+		t.Errorf("Update after Done must not appear in output; got %q", errBuf.String())
+	}
+}
+
 func TestReporter_SpinTTYFail(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/silent_reporter.go
+++ b/internal/cli/silent_reporter.go
@@ -75,6 +75,8 @@ type silentSpinner struct {
 	finished bool
 }
 
+func (s *silentSpinner) Update(string) {}
+
 func (s *silentSpinner) Done(string) {
 	if s.finished {
 		return

--- a/internal/cli/spinner.go
+++ b/internal/cli/spinner.go
@@ -13,12 +13,17 @@ import (
 // animates bubbles/spinner frames on a goroutine; in non-TTY mode it stays
 // silent until Done/Fail emits a single completion line, so logs only carry
 // terminal states (no "starting X..." narration).
+//
+// The animated label is held in msg under mu so callers can swap it
+// mid-flight via Update (e.g. countdown-style "(~N min left)" labels). The
+// animate goroutine reads msg on every frame.
 type spinner struct {
 	w        io.Writer
 	tty      bool
 	stop     chan struct{}
 	done     chan struct{}
 	mu       sync.Mutex
+	msg      string
 	finished bool
 	r        *Reporter
 }
@@ -32,6 +37,7 @@ func newSpinner(r *Reporter, msg string) *spinner {
 		tty:  r.errTTY,
 		stop: make(chan struct{}),
 		done: make(chan struct{}),
+		msg:  msg,
 		r:    r,
 	}
 	if !s.tty {
@@ -39,11 +45,23 @@ func newSpinner(r *Reporter, msg string) *spinner {
 		close(s.done)
 		return s
 	}
-	go s.animate(msg)
+	go s.animate()
 	return s
 }
 
-func (s *spinner) animate(msg string) {
+// Update swaps the animated label. In TTY mode the next frame renders the
+// new label; in non-TTY mode Update is a no-op so logs are not narrated
+// mid-flight.
+func (s *spinner) Update(msg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.finished {
+		return
+	}
+	s.msg = msg
+}
+
+func (s *spinner) animate() {
 	defer close(s.done)
 	frames := bspinner.MiniDot.Frames
 	fps := bspinner.MiniDot.FPS
@@ -54,6 +72,9 @@ func (s *spinner) animate(msg string) {
 	defer ticker.Stop()
 	idx := 0
 	render := func() {
+		s.mu.Lock()
+		msg := s.msg
+		s.mu.Unlock()
 		frame := styles.step.Render(frames[idx%len(frames)])
 		// \r returns to line start; \033[K clears to end of line.
 		fmt.Fprintf(s.w, "\r\033[K%s %s", frame, msg)

--- a/internal/edit/workflow.go
+++ b/internal/edit/workflow.go
@@ -239,20 +239,53 @@ func (w *workflow) waitIfRequested(ctx context.Context, appID, envID string, dep
 	switch {
 	case opts.WaitDeploy:
 		pb := w.reporter.Progress("Deploying...")
-		if err := w.awsClient.WaitForDeploymentPhase(ctx, appID, envID, deploymentNumber, false, timeout, run.MakeDeploymentTick(pb)); err != nil {
+		if err := w.awsClient.WaitForDeploymentPhase(ctx, appID, envID, deploymentNumber, false, timeout, run.MakeDeployTick(pb, "Baking...")); err != nil {
 			pb.Stop()
 			return fmt.Errorf("deployment failed: %w", err)
 		}
 		pb.Done("Deployment phase completed (now baking)")
 	case opts.WaitBake:
+		// Two-phase wait. The deploy phase uses a progress bar (AppConfig
+		// reports a real rollout %) and the bake phase uses a spinner with
+		// a "(~N min left)" countdown (no quantified progress is being made
+		// during bake — it's a monitoring window).
+		//
+		// waitCtx caps total wait at opts.Timeout. The per-phase timeout
+		// passed below is the remaining budget against that deadline so the
+		// inner Wait* timeout reflects "how long this phase may still take",
+		// not the original full budget.
+		deadline := time.Now().Add(timeout)
+		waitCtx, cancel := context.WithDeadline(ctx, deadline)
+		defer cancel()
+
 		pb := w.reporter.Progress("Deploying...")
-		if err := w.awsClient.WaitForDeploymentPhase(ctx, appID, envID, deploymentNumber, true, timeout, run.MakeDeploymentTick(pb)); err != nil {
+		if err := w.awsClient.WaitForDeploymentPhase(waitCtx, appID, envID, deploymentNumber, false, remainingDuration(deadline), run.MakeDeployTick(pb, "Deploying...")); err != nil {
 			pb.Stop()
 			return fmt.Errorf("deployment failed: %w", err)
 		}
-		pb.Done("Deployment completed successfully")
+		pb.Done("Deployment phase completed (now baking)")
+
+		bakeSpin := w.reporter.Spin("Baking...")
+		if err := w.awsClient.WaitForBakingComplete(waitCtx, appID, envID, deploymentNumber, remainingDuration(deadline), run.MakeBakeTick(bakeSpin)); err != nil {
+			bakeSpin.Stop()
+			return fmt.Errorf("deployment failed: %w", err)
+		}
+		bakeSpin.Done("Deployment completed successfully")
 	default:
 		w.reporter.Warn(fmt.Sprintf("Deployment #%d is in progress. Use 'apcdeploy status' to check the status.", deploymentNumber))
 	}
 	return nil
+}
+
+// remainingDuration returns the time until deadline, clamped at 1s to
+// avoid passing 0/negative values to wait functions that interpret 0 as
+// "no timeout". The actual wait is bounded by the shared waitCtx deadline
+// regardless, so the floor only matters when this helper is called after
+// the budget is already exhausted.
+func remainingDuration(deadline time.Time) time.Duration {
+	remaining := time.Until(deadline)
+	if remaining < time.Second {
+		return time.Second
+	}
+	return remaining
 }

--- a/internal/edit/workflow_test.go
+++ b/internal/edit/workflow_test.go
@@ -476,6 +476,23 @@ func TestWaitIfRequested(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		assertContainsMessage(t, rep.Messages, "Deployment completed successfully")
+
+		// --wait-bake must split into a deploy progress bar (real rollout
+		// %) and a bake spinner (monitoring wait, no quantified progress)
+		// so the user gets feedback during the bake window without being
+		// misled into thinking deployment work is still happening.
+		if got := len(rep.ProgressCalls); got != 1 {
+			t.Fatalf("expected 1 progress bar (deploy), got %d: %+v", got, rep.ProgressCalls)
+		}
+		if rep.ProgressCalls[0].StartMessage != "Deploying..." {
+			t.Errorf("deploy progress bar start = %q, want %q", rep.ProgressCalls[0].StartMessage, "Deploying...")
+		}
+		if got := len(rep.SpinnerCalls); got != 1 {
+			t.Fatalf("expected 1 spinner (bake), got %d: %+v", got, rep.SpinnerCalls)
+		}
+		if rep.SpinnerCalls[0].StartMessage != "Baking..." {
+			t.Errorf("bake spinner start = %q, want %q", rep.SpinnerCalls[0].StartMessage, "Baking...")
+		}
 	})
 
 	t.Run("wait-deploy propagates error", func(t *testing.T) {

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -65,6 +65,12 @@ type Reporter interface {
 // Spinner is the handle returned by Reporter.Spin. Callers MUST call exactly
 // one of Done, Fail, or Stop to terminate the spinner.
 type Spinner interface {
+	// Update replaces the spinner's animated label without changing its
+	// running state. In TTY mode the next animation frame renders the new
+	// message in place. In non-TTY mode Update is silent (matching the
+	// "no narration mid-flight" rule for spinners). Update is safe to call
+	// from a different goroutine than the one running the animation.
+	Update(msg string)
 	// Done stops the spinner and reports a success line with the given message.
 	Done(msg string)
 	// Fail stops the spinner and reports an error line with the given message.

--- a/internal/reporter/testing/mock.go
+++ b/internal/reporter/testing/mock.go
@@ -75,10 +75,12 @@ type BoxCall struct {
 }
 
 // SpinnerCall captures the lifecycle of a single spinner: the message passed
-// to Spin, plus the terminating Done/Fail outcome and message.
+// to Spin, the sequence of Update labels mid-flight, plus the terminating
+// Done/Fail outcome and message.
 type SpinnerCall struct {
 	StartMessage string
-	Outcome      string // "done" or "fail"
+	Updates      []string
+	Outcome      string // "done", "fail", or "stop"
 	EndMessage   string
 }
 
@@ -169,6 +171,14 @@ type mockSpinner struct {
 	m        *MockReporter
 	idx      int
 	finished bool
+}
+
+func (s *mockSpinner) Update(msg string) {
+	if s.finished {
+		return
+	}
+	s.m.SpinnerCalls[s.idx].Updates = append(s.m.SpinnerCalls[s.idx].Updates, msg)
+	s.m.Messages = append(s.m.Messages, "spin-update: "+msg)
 }
 
 func (s *mockSpinner) Done(msg string) {

--- a/internal/run/deploy.go
+++ b/internal/run/deploy.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,23 +136,76 @@ func (d *Deployer) WaitForDeploymentPhase(ctx context.Context, resolved *aws.Res
 	return d.awsClient.WaitForDeploymentPhase(ctx, resolved.ApplicationID, resolved.EnvironmentID, deploymentNumber, waitForBaking, timeout, onTick)
 }
 
-// MakeDeploymentTick returns an aws.DeploymentTickFunc that drives a progress
-// bar from deployment polling. While DEPLOYING the bar reflects
-// PercentageComplete; once BAKING starts the percentage pins at 100% and the
-// label is swapped to "Baking..." so the bar reads naturally during the bake
-// phase.
+// WaitForBakingComplete waits for an already-baking deployment to reach
+// COMPLETE. onTick is invoked on each polling tick with bake progress; nil is
+// allowed.
+func (d *Deployer) WaitForBakingComplete(ctx context.Context, resolved *aws.ResolvedResources, deploymentNumber int32, timeoutSeconds int, onTick aws.BakeTickFunc) error {
+	timeout := time.Duration(timeoutSeconds) * time.Second
+	return d.awsClient.WaitForBakingComplete(ctx, resolved.ApplicationID, resolved.EnvironmentID, deploymentNumber, timeout, onTick)
+}
+
+// MakeDeployTick returns an aws.DeploymentTickFunc that drives a deploy
+// progress bar. While DEPLOYING the bar reflects AppConfig's
+// PercentageComplete; once BAKING (or COMPLETE) is observed the percentage
+// pins at 100% and the label switches to bakingLabel.
+//
+// bakingLabel encodes how the deploy bar terminates relative to the
+// surrounding wait orchestration:
+//   - "Baking..."     when this bar is the only progress UI (--wait-deploy):
+//     the wait loop exits as soon as BAKING is observed, so
+//     the user briefly sees the bar pinned at 100% with the
+//     bake label before pb.Done() prints the success line.
+//   - "Deploying..."  when a separate spinner takes over for bake
+//     (--wait-bake): the deploy bar is finalized and a
+//     dedicated bake spinner is started after pb.Done().
+//
+// The "(~N min left)" suffix is wall-clock based (totalDuration minus
+// locally tracked elapsed time) so non-linear growth strategies
+// (EXPONENTIAL) report honest remaining time. The bar percentage is left as
+// AppConfig's PercentageComplete so the rollout-progress reading is not
+// fabricated.
 //
 // Currently shared between `run` and `edit` only. If a third caller appears,
 // move this to a neutral location (e.g. internal/aws or a new internal
 // package) so feature packages stop reaching across to `run` for the helper.
-func MakeDeploymentTick(pb reporter.ProgressBar) aws.DeploymentTickFunc {
-	return func(state types.DeploymentState, percent float64) {
-		if state == types.DeploymentStateBaking {
-			pb.Update(100, "Baking...")
+func MakeDeployTick(pb reporter.ProgressBar, bakingLabel string) aws.DeploymentTickFunc {
+	waitStart := time.Now()
+	return func(state types.DeploymentState, percent float64, totalDuration time.Duration) {
+		if state == types.DeploymentStateBaking || state == types.DeploymentStateComplete {
+			pb.Update(100, bakingLabel)
 			return
 		}
-		pb.Update(percent, "Deploying...")
+		elapsed := time.Since(waitStart)
+		pb.Update(percent, "Deploying..."+remainingFromElapsedSuffix(elapsed, totalDuration))
 	}
+}
+
+// MakeBakeTick returns an aws.BakeTickFunc that updates a Spinner's
+// label with the current "(~N min left)" countdown each tick. Bake is a
+// monitoring wait rather than a quantified rollout, so the UX is a spinner
+// (no bar): the % "filling" of a progress bar would falsely suggest that
+// rollout work is still happening, when in fact the deployment is just
+// waiting out FinalBakeTimeInMinutes.
+func MakeBakeTick(s reporter.Spinner) aws.BakeTickFunc {
+	return func(elapsed, total time.Duration) {
+		s.Update("Baking..." + remainingFromElapsedSuffix(elapsed, total))
+	}
+}
+
+// remainingFromElapsedSuffix renders a "(~N min left)" suffix from total
+// minus locally observed elapsed time. Falls back to "(<1 min left)" when
+// total is zero (e.g. AppConfig.AllAtOnce), when elapsed has already run
+// past total, or when the remaining is below one minute. The function
+// always returns a non-empty string so the bar always carries a time hint,
+// and the threshold is on the duration itself (not math.Ceil) so 30 s and
+// 59 s render honestly as "<1 min left" instead of being rounded up to
+// "~1 min left".
+func remainingFromElapsedSuffix(elapsed, total time.Duration) string {
+	remaining := total - elapsed
+	if total <= 0 || remaining < time.Minute {
+		return " (<1 min left)"
+	}
+	return fmt.Sprintf(" (~%d min left)", int(math.Ceil(remaining.Minutes())))
 }
 
 // HasConfigurationChanges checks if the local configuration differs from the deployed version

--- a/internal/run/deploy_test.go
+++ b/internal/run/deploy_test.go
@@ -878,23 +878,39 @@ func TestHasConfigurationChanges(t *testing.T) {
 	}
 }
 
-// TestMakeDeploymentTick verifies that the helper translates AppConfig
-// deployment states into progress-bar updates, including the BAKING-pins-to-100%
-// behavior that callers in run/edit rely on.
-func TestMakeDeploymentTick(t *testing.T) {
+// TestMakeDeployTick verifies the state-machine branches of the deploy
+// tick factory across both bakingLabel modes:
+//   - "Baking..."     (--wait-deploy: bar terminates with bake label)
+//   - "Deploying..."  (--wait-bake's deploy phase: bar terminates with
+//     deploy label, then a separate spinner takes over)
+//
+// All other states route to the "Deploying..." label with a wall-clock
+// remaining-time suffix. Tests fire the tick immediately after closure
+// construction so elapsed is effectively zero, making the suffix
+// deterministic.
+func TestMakeDeployTick(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		state       types.DeploymentState
-		percent     float64
-		wantPercent float64
-		wantMsg     string
+		name          string
+		bakingLabel   string
+		state         types.DeploymentState
+		percent       float64
+		totalDuration time.Duration
+		wantPercent   float64
+		wantMsg       string
 	}{
-		{"deploying mid", types.DeploymentStateDeploying, 42.5, 42.5, "Deploying..."},
-		{"deploying zero", types.DeploymentStateDeploying, 0, 0, "Deploying..."},
-		{"baking pins to 100", types.DeploymentStateBaking, 30, 100, "Baking..."},
-		{"complete falls through to deploying label", types.DeploymentStateComplete, 100, 100, "Deploying..."},
+		// --wait-deploy mode (bakingLabel = "Baking...")
+		{"wait-deploy: deploying mid no total", "Baking...", types.DeploymentStateDeploying, 42.5, 0, 42.5, "Deploying... (<1 min left)"},
+		{"wait-deploy: deploying with total", "Baking...", types.DeploymentStateDeploying, 30, 10 * time.Minute, 30, "Deploying... (~10 min left)"},
+		{"wait-deploy: baking pins to 100 with bake label", "Baking...", types.DeploymentStateBaking, 30, 10 * time.Minute, 100, "Baking..."},
+		{"wait-deploy: complete pins to 100 with bake label", "Baking...", types.DeploymentStateComplete, 100, 10 * time.Minute, 100, "Baking..."},
+
+		// --wait-bake's deploy phase (bakingLabel = "Deploying...")
+		{"wait-bake: deploying mid no total", "Deploying...", types.DeploymentStateDeploying, 42.5, 0, 42.5, "Deploying... (<1 min left)"},
+		{"wait-bake: deploying with total", "Deploying...", types.DeploymentStateDeploying, 25, 8 * time.Minute, 25, "Deploying... (~8 min left)"},
+		{"wait-bake: baking pins to 100 with deploy label", "Deploying...", types.DeploymentStateBaking, 30, 8 * time.Minute, 100, "Deploying..."},
+		{"wait-bake: complete pins to 100 with deploy label", "Deploying...", types.DeploymentStateComplete, 100, 8 * time.Minute, 100, "Deploying..."},
 	}
 
 	for _, tt := range tests {
@@ -902,8 +918,8 @@ func TestMakeDeploymentTick(t *testing.T) {
 			t.Parallel()
 			m := &reportertest.MockReporter{}
 			pb := m.Progress("init")
-			tick := MakeDeploymentTick(pb)
-			tick(tt.state, tt.percent)
+			tick := MakeDeployTick(pb, tt.bakingLabel)
+			tick(tt.state, tt.percent, tt.totalDuration)
 
 			if len(m.ProgressCalls) != 1 || len(m.ProgressCalls[0].Updates) != 1 {
 				t.Fatalf("expected exactly one update; got %+v", m.ProgressCalls)
@@ -911,6 +927,81 @@ func TestMakeDeploymentTick(t *testing.T) {
 			got := m.ProgressCalls[0].Updates[0]
 			if got.Percent != tt.wantPercent || got.Message != tt.wantMsg {
 				t.Errorf("update = %+v, want percent=%v msg=%q", got, tt.wantPercent, tt.wantMsg)
+			}
+		})
+	}
+}
+
+// TestRemainingFromElapsedSuffix exercises the time-boundary edge cases
+// (sub-minute, exact minute, overshoot, zero total) directly. The
+// MakeDeployTick / MakeBakeTick tests cover routing
+// only because elapsed is timing-dependent; this table-driven test
+// covers the formatting decisions independently.
+func TestRemainingFromElapsedSuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		elapsed time.Duration
+		total   time.Duration
+		want    string
+	}{
+		{"zero total falls back to <1 min", 0, 0, " (<1 min left)"},
+		{"negative-looking total falls back to <1 min", 0, -5 * time.Minute, " (<1 min left)"},
+		{"start of window shows full duration", 0, 10 * time.Minute, " (~10 min left)"},
+		{"mid window rounds up partial minute", 3 * time.Minute, 10 * time.Minute, " (~7 min left)"},
+		{"exactly one minute remaining renders as 1 min", 9 * time.Minute, 10 * time.Minute, " (~1 min left)"},
+		{"non-integer remaining rounds up", 0, 2*time.Minute + 30*time.Second, " (~3 min left)"},
+		{"thirty seconds remaining clamps to <1 min", 9*time.Minute + 30*time.Second, 10 * time.Minute, " (<1 min left)"},
+		{"sub-second remaining clamps to <1 min", 9*time.Minute + 59*time.Second + 500*time.Millisecond, 10 * time.Minute, " (<1 min left)"},
+		{"elapsed equals total clamps to <1 min", 10 * time.Minute, 10 * time.Minute, " (<1 min left)"},
+		{"elapsed exceeds total clamps to <1 min", 12 * time.Minute, 10 * time.Minute, " (<1 min left)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := remainingFromElapsedSuffix(tt.elapsed, tt.total); got != tt.want {
+				t.Errorf("remainingFromElapsedSuffix(%v, %v) = %q, want %q", tt.elapsed, tt.total, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMakeBakeTick verifies that the bake-spinner tick updates the
+// underlying Spinner's label with a "(~N min left)" suffix derived from
+// elapsed/total.
+func TestMakeBakeTick(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		elapsed time.Duration
+		total   time.Duration
+		wantMsg string
+	}{
+		{"zero total falls back to <1 min", 0, 0, "Baking... (<1 min left)"},
+		{"early in bake shows full window", 0, 10 * time.Minute, "Baking... (~10 min left)"},
+		{"mid bake shows remaining", 5 * time.Minute, 10 * time.Minute, "Baking... (~5 min left)"},
+		{"sub-minute remaining clamps to <1 min", 9*time.Minute + 30*time.Second, 10 * time.Minute, "Baking... (<1 min left)"},
+		{"elapsed equals total clamps to <1 min", 10 * time.Minute, 10 * time.Minute, "Baking... (<1 min left)"},
+		{"elapsed exceeds total clamps to <1 min", 11 * time.Minute, 10 * time.Minute, "Baking... (<1 min left)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &reportertest.MockReporter{}
+			sp := m.Spin("init")
+			tick := MakeBakeTick(sp)
+			tick(tt.elapsed, tt.total)
+
+			if len(m.SpinnerCalls) != 1 || len(m.SpinnerCalls[0].Updates) != 1 {
+				t.Fatalf("expected exactly one update; got %+v", m.SpinnerCalls)
+			}
+			got := m.SpinnerCalls[0].Updates[0]
+			if got != tt.wantMsg {
+				t.Errorf("update = %q, want %q", got, tt.wantMsg)
 			}
 		})
 	}

--- a/internal/run/executor.go
+++ b/internal/run/executor.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/koh-sh/apcdeploy/internal/aws"
 	"github.com/koh-sh/apcdeploy/internal/config"
@@ -151,20 +152,40 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 	case opts.WaitDeploy:
 		// Wait for deploy phase only (until BAKING starts)
 		pb := e.reporter.Progress("Deploying...")
-		if err := deployer.WaitForDeploymentPhase(ctx, resolved, deploymentNumber, false, opts.Timeout, MakeDeploymentTick(pb)); err != nil {
+		if err := deployer.WaitForDeploymentPhase(ctx, resolved, deploymentNumber, false, opts.Timeout, MakeDeployTick(pb, "Baking...")); err != nil {
 			pb.Stop()
 			return fmt.Errorf("deployment failed: %w", err)
 		}
 		pb.Done("Deployment phase completed (now baking)")
 
 	case opts.WaitBake:
-		// Wait for complete deployment (deploy + bake)
+		// Two-phase wait. The deploy phase uses a progress bar (AppConfig
+		// reports a real rollout %) and the bake phase uses a spinner with a
+		// "(~N min left)" countdown (no quantified progress is being made —
+		// it's just a monitoring window).
+		//
+		// waitCtx caps total wait at opts.Timeout. The per-phase timeout
+		// passed below is the remaining budget against that deadline so the
+		// inner Wait* timeout reflects "how long this phase may still take",
+		// not the original full budget. This keeps the timed-out error
+		// message ("bake phase timed out after X") meaningful.
+		deadline := time.Now().Add(time.Duration(opts.Timeout) * time.Second)
+		waitCtx, cancel := context.WithDeadline(ctx, deadline)
+		defer cancel()
+
 		pb := e.reporter.Progress("Deploying...")
-		if err := deployer.WaitForDeploymentPhase(ctx, resolved, deploymentNumber, true, opts.Timeout, MakeDeploymentTick(pb)); err != nil {
+		if err := deployer.WaitForDeploymentPhase(waitCtx, resolved, deploymentNumber, false, remainingSeconds(deadline), MakeDeployTick(pb, "Deploying...")); err != nil {
 			pb.Stop()
 			return fmt.Errorf("deployment failed: %w", err)
 		}
-		pb.Done("Deployment completed successfully")
+		pb.Done("Deployment phase completed (now baking)")
+
+		bakeSpin := e.reporter.Spin("Baking...")
+		if err := deployer.WaitForBakingComplete(waitCtx, resolved, deploymentNumber, remainingSeconds(deadline), MakeBakeTick(bakeSpin)); err != nil {
+			bakeSpin.Stop()
+			return fmt.Errorf("deployment failed: %w", err)
+		}
+		bakeSpin.Done("Deployment completed successfully")
 
 	default:
 		// No wait requested
@@ -172,4 +193,17 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 	}
 
 	return nil
+}
+
+// remainingSeconds returns the seconds remaining until deadline, clamped at
+// 1 to avoid passing 0/negative values to wait functions that interpret 0
+// as "no timeout". The actual wait is bounded by the shared waitCtx
+// deadline regardless, so the floor only matters when this helper is
+// called after the budget is already exhausted.
+func remainingSeconds(deadline time.Time) int {
+	remaining := int(time.Until(deadline).Seconds())
+	if remaining < 1 {
+		return 1
+	}
+	return remaining
 }

--- a/internal/run/executor_test.go
+++ b/internal/run/executor_test.go
@@ -286,35 +286,50 @@ region: us-east-1
 	}
 }
 
-// TestExecutorFullWorkflowWithWait tests deployment with wait options
+// TestExecutorFullWorkflowWithWait tests deployment with wait options.
+// For --wait-bake we assert that the deploy phase gets a progress bar and
+// the bake phase gets a spinner, since deploy is a quantified rollout
+// (AWS-reported %) and bake is just a monitoring wait.
 func TestExecutorFullWorkflowWithWait(t *testing.T) {
 	tests := []struct {
-		name       string
-		waitDeploy bool
-		waitBake   bool
-		mockStates []types.DeploymentState
-		wantMsg    string
+		name             string
+		waitDeploy       bool
+		waitBake         bool
+		mockStates       []types.DeploymentState
+		wantMsg          string
+		wantProgressBars int
+		wantSpinners     int
+		wantBakeSpinner  bool
 	}{
 		{
-			name:       "wait for bake: immediate completion",
-			waitDeploy: false,
-			waitBake:   true,
-			mockStates: []types.DeploymentState{types.DeploymentStateComplete},
-			wantMsg:    "Deployment completed successfully",
+			name:             "wait for bake: immediate completion",
+			waitDeploy:       false,
+			waitBake:         true,
+			mockStates:       []types.DeploymentState{types.DeploymentStateComplete},
+			wantMsg:          "Deployment completed successfully",
+			wantProgressBars: 1,
+			wantSpinners:     1,
+			wantBakeSpinner:  true,
 		},
 		{
-			name:       "wait for bake: completion after polling",
-			waitDeploy: false,
-			waitBake:   true,
-			mockStates: []types.DeploymentState{types.DeploymentStateDeploying, types.DeploymentStateBaking, types.DeploymentStateComplete},
-			wantMsg:    "Deployment completed successfully",
+			name:             "wait for bake: completion after polling",
+			waitDeploy:       false,
+			waitBake:         true,
+			mockStates:       []types.DeploymentState{types.DeploymentStateDeploying, types.DeploymentStateBaking, types.DeploymentStateComplete},
+			wantMsg:          "Deployment completed successfully",
+			wantProgressBars: 1,
+			wantSpinners:     1,
+			wantBakeSpinner:  true,
 		},
 		{
-			name:       "wait for deploy: stops at baking",
-			waitDeploy: true,
-			waitBake:   false,
-			mockStates: []types.DeploymentState{types.DeploymentStateDeploying, types.DeploymentStateBaking},
-			wantMsg:    "Deployment phase completed (now baking)",
+			name:             "wait for deploy: stops at baking",
+			waitDeploy:       true,
+			waitBake:         false,
+			mockStates:       []types.DeploymentState{types.DeploymentStateDeploying, types.DeploymentStateBaking},
+			wantMsg:          "Deployment phase completed (now baking)",
+			wantProgressBars: 1,
+			wantSpinners:     0,
+			wantBakeSpinner:  false,
 		},
 	}
 
@@ -422,6 +437,21 @@ region: us-east-1
 
 			if !hasExpectedMsg {
 				t.Errorf("expected message containing %q, got messages: %v", tt.wantMsg, reporter.Messages)
+			}
+
+			if got := len(reporter.ProgressCalls); got != tt.wantProgressBars {
+				t.Errorf("progress bar count = %d, want %d (calls: %+v)", got, tt.wantProgressBars, reporter.ProgressCalls)
+			}
+			if len(reporter.ProgressCalls) > 0 && reporter.ProgressCalls[0].StartMessage != "Deploying..." {
+				t.Errorf("first progress bar start = %q, want %q", reporter.ProgressCalls[0].StartMessage, "Deploying...")
+			}
+			if got := len(reporter.SpinnerCalls); got != tt.wantSpinners {
+				t.Errorf("spinner count = %d, want %d (calls: %+v)", got, tt.wantSpinners, reporter.SpinnerCalls)
+			}
+			if tt.wantBakeSpinner {
+				if len(reporter.SpinnerCalls) == 0 || reporter.SpinnerCalls[0].StartMessage != "Baking..." {
+					t.Errorf("bake spinner start = %+v, want StartMessage=%q", reporter.SpinnerCalls, "Baking...")
+				}
 			}
 		})
 	}

--- a/llms.md
+++ b/llms.md
@@ -596,6 +596,8 @@ apcdeploy run -c apcdeploy.yml --wait-bake --timeout 900
 | `--wait-deploy` | Deployment phase only | When entering baking state | Cases where you need to synchronously wait for deployment phase completion |
 | `--wait-bake` | Complete deployment | When deployment becomes COMPLETE | Cases where you need to synchronously wait for full deployment completion |
 
+When using `--wait-bake`, the deploy phase is shown as a progress bar (AppConfig reports a real rollout %) and the bake phase is shown as a spinner (bake is just a monitoring window, not a quantified rollout). Both phases display a `(~N min left)` countdown derived from the locally observed elapsed time vs the strategy's `DeploymentDurationInMinutes` / `FinalBakeTimeInMinutes`. The total wait is bounded by `--timeout` (shared across both phases).
+
 #### Idempotency
 
 - **Auto-skip feature**: If local file content is identical to deployed version, deployment is automatically skipped


### PR DESCRIPTION
## Summary

- Redesign `--wait-bake` into two concept-aware phases: deploy = progress bar (AWS reports real rollout %), bake = spinner (just a monitoring wait, not quantified rollout work)
- Show `(~N min left)` countdown on both phases, computed from wall-clock elapsed time so non-linear growth strategies (EXPONENTIAL) still report honest remaining time
- Add `Spinner.Update(msg)` to the Reporter interface to enable mid-flight label updates

### Motivation

The previous `--wait-bake` UI used a single progress bar that pinned at 100% with a `"Baking..."` label for the entire bake window. With many predefined strategies the bake phase is longer than the deploy phase, leaving the user without feedback during the longest part of a deployment.

Beyond the missing feedback, expressing bake progress as a "filling bar" was conceptually wrong: bake is a monitoring window, not rollout work, and AppConfig itself does not surface a bake-phase percentage. A bar would falsely suggest that deployment work is still happening.

### Changes

#### Reporter contract (commit 1)
- Add `Spinner.Update(msg string)` so callers can swap the animated label without restarting the spinner — required to drive a `"Baking... (~5 min left)"` countdown from a polling loop. The cli implementation guards the message field with the existing mutex; non-TTY mode is a no-op so logs are not narrated mid-flight.

#### `--wait-bake` redesign (commit 2)
- **aws layer**: add `WaitForBakingComplete` + `BakeTickFunc(elapsed, total)` for the bake-only wait. Extract a shared `rolledBackError` helper used by both `waitForDeploymentWithCondition` and the new function.
- **tick helpers**: consolidate the previous `MakeDeploymentTick` / `MakeDeployTick` pair into a single `MakeDeployTick(pb, bakingLabel)`. The `bakingLabel` parameter selects how the deploy bar terminates: `"Baking..."` when this bar is the only progress UI (`--wait-deploy`), or `"Deploying..."` when a separate spinner takes over (`--wait-bake`). Add `MakeBakeTick(spinner)` that calls `Spinner.Update` with the countdown label each tick.
- **executor / workflow**: derive a single shared `deadline` and pass the remaining budget to each phase's wait call. The total wait stays bounded by `--timeout` and the inner timeout error becomes phase-aware (`"bake phase timed out after X"`).
- **Remaining-time math**: `total - elapsed` against the wall clock. Bar percentage stays AWS-driven so the rollout reading isn't fabricated. With EXPONENTIAL strategies the bar and the countdown advance at different paces, but each is accurate within its own meaning.

### Test plan

- [x] `mise run ci` passes (coverage 90.4%)
- [x] `go test -race ./internal/cli/...` clean (no races on the new `Spinner.Update`)
- [x] `internal/aws/deployment_test.go`: `TestWaitForBakingComplete` (state machine + tick callback) and `TestWaitForBakingComplete_TickElapsed` (elapsed monotonically advances; final tick = full bake duration)
- [x] `internal/cli/reporter_tty_test.go`: `TestReporter_SpinTTYUpdateChangesLabel` (mid-flight label change is rendered) and `TestReporter_SpinTTYUpdateAfterDoneIsNoOp` (Update after Done is ignored)
- [x] `internal/run/deploy_test.go`: `TestMakeDeployTick` (both `bakingLabel` modes), `TestMakeBakeTick` (spinner update), `TestRemainingFromElapsedSuffix` (time-boundary edge cases)
- [x] `internal/run/executor_test.go` / `internal/edit/workflow_test.go`: verify `--wait-bake` produces exactly one progress bar and one spinner
- [ ] Manual verification against real AWS (UI rendering not covered by e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)