### PR TITLE
feat(run,edit): add --description flag with apcdeploy default marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ All commands follow the pattern: `cmd/<command>.go` → `internal/<command>/exec
 **Exception**: The `context` command is a simple utility that only outputs embedded content (`llms.md`). It does not follow the standard command structure and has no corresponding `internal/context/` directory. The implementation is entirely contained in `cmd/context.go`, with the content embedded in `main.go` and passed via `cmd.SetLLMsContent()`.
 
 1. **cmd/**: Cobra command definitions and CLI flag parsing
-   - `root.go`: Root command with global flags (`--config`, `--silent`)
+   - `root.go`: Root command with global flags (`--config`, `--silent`); also hosts the `--description` shared helpers (`validateDescription` for the 1024-rune client-side limit and `resolveDescription` for the `defaultDescription` fallback) used by `run` and `edit`
    - Each command file (`init.go`, `run.go`, `diff.go`, `status.go`, `get.go`, `pull.go`, `rollback.go`, `ls_resources.go`, `edit.go`) handles CLI concerns only
    - `context.go`: Simple command that outputs embedded `llms.md` content for AI assistants (no internal package)
    - `init.go`: Supports interactive mode for resource selection; all flags are optional
@@ -166,7 +166,7 @@ Edit command implementation:
 - `executor.go`: Orchestrates the edit workflow using a `WorkflowFactory` for testability
 - `workflow.go`: Resolves the target resources (region/app/profile/env) via flags or interactive prompts, fetches the latest deployed configuration, launches the editor, validates, and deploys
 - `editor.go`: Launches `$EDITOR` (falls back to `vi`) against a temp file whose extension is derived from the content type; cleans up the temp file after use
-- `options.go`: Command-specific options struct (`Region`, `Application`, `Profile`, `Environment`, `DeploymentStrategy`, `WaitDeploy`, `WaitBake`, `Timeout`, `Silent`)
+- `options.go`: Command-specific options struct (`Region`, `Application`, `Profile`, `Environment`, `DeploymentStrategy`, `WaitDeploy`, `WaitBake`, `Timeout`, `Description`)
 - Reuses `init.InteractiveSelector` for interactive resource selection
 - No configuration file required; operates independently of `apcdeploy.yml`
 - Validation parity with `run`: same size limit and JSON/YAML syntax checks

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Options:
 - `--wait-bake`: Wait for complete deployment including baking phase
 - `--timeout`: Timeout in seconds for deployment wait (default: 1800)
 - `--force`: Deploy even if content hasn't changed
+- `--description`: Description attached to the configuration version and deployment (max 1024 chars). Defaults to `"Deployed by apcdeploy"`; pass `--description ""` to clear it.
 
 Note: `--wait-deploy` and `--wait-bake` are mutually exclusive.
 
@@ -279,6 +280,7 @@ Options:
 - `--wait-deploy`: Wait for deployment phase to complete (until baking starts)
 - `--wait-bake`: Wait for complete deployment including baking phase
 - `--timeout`: Timeout in seconds for deployment wait (default: 1800)
+- `--description`: Description attached to the configuration version and deployment (max 1024 chars). Defaults to `"Deployed by apcdeploy"`; pass `--description ""` to clear it.
 
 **Note:** This command does not use `apcdeploy.yml`.
 

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/koh-sh/apcdeploy/internal/cli"
 	"github.com/koh-sh/apcdeploy/internal/edit"
@@ -18,6 +19,7 @@ var (
 	editWaitDeploy         bool
 	editWaitBake           bool
 	editTimeout            int
+	editDescription        string
 )
 
 // EditCommand returns the edit command
@@ -50,12 +52,18 @@ JSON/YAML syntax checks).`,
 	cmd.Flags().BoolVar(&editWaitDeploy, "wait-deploy", false, "Wait for deployment phase to complete (until baking starts)")
 	cmd.Flags().BoolVar(&editWaitBake, "wait-bake", false, "Wait for complete deployment including baking phase")
 	cmd.Flags().IntVar(&editTimeout, "timeout", DefaultDeploymentTimeout, "Timeout in seconds for deployment")
+	cmd.Flags().StringVar(&editDescription, "description", "", fmt.Sprintf(`Description attached to the configuration version and deployment (max %d chars; defaults to %q, pass "" to clear)`, maxDescriptionLength, defaultDescription))
 
 	return cmd
 }
 
 func runEdit(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
+
+	if err := validateDescription(editDescription); err != nil {
+		return err
+	}
+	description := resolveDescription(cmd, editDescription)
 
 	opts := &edit.Options{
 		Region:             editRegion,
@@ -66,6 +74,7 @@ func runEdit(cmd *cobra.Command, args []string) error {
 		WaitDeploy:         editWaitDeploy,
 		WaitBake:           editWaitBake,
 		Timeout:            editTimeout,
+		Description:        description,
 	}
 
 	reporter := cli.GetReporter(isSilent())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"unicode/utf8"
 
 	awsInternal "github.com/koh-sh/apcdeploy/internal/aws"
 	"github.com/koh-sh/apcdeploy/internal/cli"
@@ -87,4 +88,39 @@ func Execute() {
 // isSilent returns whether silent mode is enabled
 func isSilent() bool {
 	return silent
+}
+
+// maxDescriptionLength matches the AppConfig API limit on the Description
+// field of CreateHostedConfigurationVersion / StartDeployment. Validating
+// locally produces a clearer error than the AWS-side ValidationException.
+const maxDescriptionLength = 1024
+
+// defaultDescription is attached to AppConfig configuration versions and
+// deployments when the user did not pass --description. It marks the change
+// as originating from apcdeploy so it can be distinguished from manual edits
+// in the AppConfig console.
+const defaultDescription = "Deployed by apcdeploy"
+
+// validateDescription enforces the AppConfig 1024-char limit on --description
+// values before the AWS round-trip. AppConfig's limit is in Unicode characters,
+// not bytes, so multibyte input (e.g. Japanese) is counted by rune.
+// Empty values are allowed — the AWS wrappers omit the field entirely when
+// description is "".
+func validateDescription(s string) error {
+	n := utf8.RuneCountInString(s)
+	if n > maxDescriptionLength {
+		return fmt.Errorf("--description exceeds maximum length of %d characters (got %d)", maxDescriptionLength, n)
+	}
+	return nil
+}
+
+// resolveDescription returns the description to attach to the configuration
+// version / deployment. When the user did not pass --description, the default
+// marker is used. An explicit --description "" keeps the empty value (opt-out)
+// — Cobra's Changed() flag distinguishes "not set" from "set to empty".
+func resolveDescription(cmd *cobra.Command, value string) string {
+	if cmd.Flags().Changed("description") {
+		return value
+	}
+	return defaultDescription
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/koh-sh/apcdeploy/internal/cli"
 	"github.com/koh-sh/apcdeploy/internal/run"
@@ -18,10 +19,11 @@ const (
 )
 
 var (
-	runWaitDeploy bool
-	runWaitBake   bool
-	runTimeout    int
-	runForce      bool
+	runWaitDeploy  bool
+	runWaitBake    bool
+	runTimeout     int
+	runForce       bool
+	runDescription string
 )
 
 // RunCommand returns the run command
@@ -49,6 +51,7 @@ This command will:
 	cmd.Flags().BoolVar(&runWaitBake, "wait-bake", false, "Wait for complete deployment including baking phase")
 	cmd.Flags().IntVar(&runTimeout, "timeout", DefaultDeploymentTimeout, "Timeout in seconds for deployment")
 	cmd.Flags().BoolVar(&runForce, "force", false, "Force deployment even when there are no changes")
+	cmd.Flags().StringVar(&runDescription, "description", "", fmt.Sprintf(`Description attached to the configuration version and deployment (max %d chars; defaults to %q, pass "" to clear)`, maxDescriptionLength, defaultDescription))
 
 	return cmd
 }
@@ -56,19 +59,22 @@ This command will:
 func runRun(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// Create options
+	if err := validateDescription(runDescription); err != nil {
+		return err
+	}
+	description := resolveDescription(cmd, runDescription)
+
 	opts := &run.Options{
-		ConfigFile: configFile,
-		WaitDeploy: runWaitDeploy,
-		WaitBake:   runWaitBake,
-		Timeout:    runTimeout,
-		Force:      runForce,
+		ConfigFile:  configFile,
+		WaitDeploy:  runWaitDeploy,
+		WaitBake:    runWaitBake,
+		Timeout:     runTimeout,
+		Force:       runForce,
+		Description: description,
 	}
 
-	// Create reporter
 	reporter := cli.GetReporter(isSilent())
 
-	// Run deployment
 	executor := run.NewExecutor(reporter)
 	return executor.Execute(ctx, opts)
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -34,11 +35,14 @@ func TestRunCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Reset global flags for each test
+			// Reset global flags for each test. We touch every flag-bound
+			// global so `go test -shuffle=on` can't expose ordering bugs.
 			configFile = "apcdeploy.yml"
 			runWaitDeploy = false
 			runWaitBake = false
 			runTimeout = DefaultDeploymentTimeout
+			runForce = false
+			runDescription = ""
 
 			cmd := newRunCmd()
 			cmd.SetArgs(tt.args)
@@ -56,6 +60,8 @@ func TestRunCommandFlags(t *testing.T) {
 	runWaitDeploy = false
 	runWaitBake = false
 	runTimeout = DefaultDeploymentTimeout
+	runForce = false
+	runDescription = ""
 
 	cmd := newRunCmd()
 
@@ -91,6 +97,8 @@ func TestRunCommandWaitFlags(t *testing.T) {
 	runWaitDeploy = false
 	runWaitBake = false
 	runTimeout = DefaultDeploymentTimeout
+	runForce = false
+	runDescription = ""
 
 	cmd := newRunCmd()
 
@@ -140,8 +148,15 @@ func TestRunTimeoutValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// resolveDescription inside runRun reads cmd.Flags(), so a nil cmd
+			// would panic. Build a real run command, then override the timeout
+			// global AFTER newRunCmd() — IntVar registration resets the flag
+			// to its default during construction.
+			cmd := newRunCmd()
 			runTimeout = tt.timeout
-			err := runRun(nil, nil)
+			runDescription = ""
+
+			err := runRun(cmd, nil)
 
 			if tt.wantErr {
 				if err == nil {
@@ -160,5 +175,66 @@ func TestRunCommandSilenceUsage(t *testing.T) {
 	// SilenceUsage should be true to prevent usage display on runtime errors
 	if !cmd.SilenceUsage {
 		t.Error("run command should have SilenceUsage set to true")
+	}
+}
+
+// TestResolveDescription verifies the default-vs-explicit behavior:
+//   - flag not passed → defaultDescription marker
+//   - --description "x" → "x"
+//   - --description "" (explicit empty) → "" (opt-out from default)
+//
+// We use a freshly constructed run command so the test owns the flag state
+// and isn't affected by leftover globals from neighboring tests.
+func TestResolveDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "not passed uses default", args: []string{}, want: defaultDescription},
+		{name: "explicit value", args: []string{"--description", "hotfix"}, want: "hotfix"},
+		{name: "explicit empty opts out", args: []string{"--description", ""}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runDescription = ""
+			cmd := newRunCmd()
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			got := resolveDescription(cmd, runDescription)
+			if got != tt.want {
+				t.Errorf("resolveDescription = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateDescription covers the 1024-rune client-side guard. We exercise
+// the boundary explicitly (1024 OK, 1025 rejected) for both ASCII and a
+// multibyte rune so a regression to byte-counting (len(s) > 1024) would be
+// caught — "あ" is 3 UTF-8 bytes, so 1024 of them is 3072 bytes.
+func TestValidateDescription(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty", input: "", wantErr: false},
+		{name: "short", input: "hotfix", wantErr: false},
+		{name: "exactly 1024 ascii", input: strings.Repeat("a", 1024), wantErr: false},
+		{name: "1025 ascii rejected", input: strings.Repeat("a", 1025), wantErr: true},
+		{name: "exactly 1024 multibyte", input: strings.Repeat("あ", 1024), wantErr: false},
+		{name: "1025 multibyte rejected", input: strings.Repeat("あ", 1025), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDescription(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateDescription(runes=%d) error = %v, wantErr %v", len([]rune(tt.input)), err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -135,6 +135,28 @@ $APCDEPLOY get --silent --yes | jq -e '.e == "new"' > /dev/null
 EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"e":"new"}' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile json-freeform --env dev 2>&1 | grep -q "No changes detected"
 if EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='not-json' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile json-freeform --env dev --silent; then exit 1; fi
 
+echo "Description: default marker, explicit value, opt-out, length cap, edit"
+title "========== S8: Description =========="
+$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
+use_strategy
+echo '{"d":"1"}' > data.json
+$APCDEPLOY run --wait-bake --silent
+# status renders Description on stderr via Reporter.Table (tab-separated in
+# non-TTY mode) — grep stderr to verify the value is what we expect.
+$APCDEPLOY status 2>&1 | grep -qF "Deployed by apcdeploy"
+echo '{"d":"2"}' > data.json
+$APCDEPLOY run --wait-bake --silent --description "explicit run desc"
+$APCDEPLOY status 2>&1 | grep -qF "explicit run desc"
+echo '{"d":"3"}' > data.json
+$APCDEPLOY run --wait-bake --silent --description ""
+# Empty --description opts out of the default; no Description row should appear.
+if $APCDEPLOY status 2>&1 | grep -q "^Description"; then exit 1; fi
+# >1024 runes is rejected client-side before any AWS round-trip.
+LONG_DESC=$(printf 'a%.0s' {1..1025})
+if $APCDEPLOY run --silent --description "$LONG_DESC"; then exit 1; fi
+EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"d":"edited"}' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile json-freeform --env dev --wait-bake --silent --description "explicit edit desc"
+$APCDEPLOY status 2>&1 | grep -qF "explicit edit desc"
+
 echo "Error handling: non-existent resources (app/profile/env)"
 title "========== E1: Resource Errors =========="
 if $APCDEPLOY init --silent --app xxx --profile test --env dev --region "$REGION"; then exit 1; fi

--- a/internal/edit/options.go
+++ b/internal/edit/options.go
@@ -10,4 +10,5 @@ type Options struct {
 	WaitDeploy         bool
 	WaitBake           bool
 	Timeout            int
+	Description        string
 }

--- a/internal/edit/workflow.go
+++ b/internal/edit/workflow.go
@@ -196,7 +196,7 @@ func (w *workflow) editAndDeploy(ctx context.Context, t *resolvedTargets, deploy
 	}
 
 	sp := w.reporter.Spin("Creating configuration version...")
-	versionNumber, err := w.awsClient.CreateHostedConfigurationVersion(ctx, t.AppID, t.Profile.ID, edited, deployed.ContentType, "")
+	versionNumber, err := w.awsClient.CreateHostedConfigurationVersion(ctx, t.AppID, t.Profile.ID, edited, deployed.ContentType, opts.Description)
 	if err != nil {
 		sp.Stop()
 		if awsInternal.IsValidationError(err) {
@@ -207,7 +207,7 @@ func (w *workflow) editAndDeploy(ctx context.Context, t *resolvedTargets, deploy
 	sp.Done(fmt.Sprintf("Created configuration version %d", versionNumber))
 
 	sp = w.reporter.Spin("Starting deployment...")
-	deploymentNumber, err := w.awsClient.StartDeployment(ctx, t.AppID, t.EnvID, t.Profile.ID, strategyID, versionNumber, "")
+	deploymentNumber, err := w.awsClient.StartDeployment(ctx, t.AppID, t.EnvID, t.Profile.ID, strategyID, versionNumber, opts.Description)
 	if err != nil {
 		sp.Stop()
 		return fmt.Errorf("failed to start deployment: %w", err)

--- a/internal/edit/workflow_test.go
+++ b/internal/edit/workflow_test.go
@@ -699,3 +699,72 @@ func TestWorkflowFeatureFlagsIgnoresMetadata(t *testing.T) {
 
 	assertContainsMessage(t, rep.Messages, "No changes detected")
 }
+
+// TestWorkflowForwardsDescription verifies that opts.Description reaches both
+// CreateHostedConfigurationVersion and StartDeployment when set, and that an
+// empty value leaves the field unset on both calls (so AppConfig keeps its
+// default behavior).
+func TestWorkflowForwardsDescription(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		wantNil     bool
+		wantValue   string
+	}{
+		{name: "empty omits field", description: "", wantNil: true},
+		{name: "explicit description forwarded", description: "hotfix: bump retry limit", wantValue: "hotfix: bump retry limit"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeEditorScript(t, `{"key":"updated"}`)
+
+			deployedContent := []byte(`{"key":"value"}`)
+			client := baseMockClient(deployedContent, "application/json")
+
+			var capturedVersionDesc, capturedDeploymentDesc *string
+			client.CreateHostedConfigurationVersionFunc = func(ctx context.Context, params *appconfig.CreateHostedConfigurationVersionInput, optFns ...func(*appconfig.Options)) (*appconfig.CreateHostedConfigurationVersionOutput, error) {
+				capturedVersionDesc = params.Description
+				return &appconfig.CreateHostedConfigurationVersionOutput{VersionNumber: 4}, nil
+			}
+			client.StartDeploymentFunc = func(ctx context.Context, params *appconfig.StartDeploymentInput, optFns ...func(*appconfig.Options)) (*appconfig.StartDeploymentOutput, error) {
+				capturedDeploymentDesc = params.Description
+				return &appconfig.StartDeploymentOutput{DeploymentNumber: 8}, nil
+			}
+
+			awsClient := awsInternal.NewTestClient(client)
+			wf := newWorkflowWithClient(awsClient, &promptTesting.MockPrompter{}, &reporterTesting.MockReporter{})
+
+			opts := &Options{
+				Region:      "us-east-1",
+				Application: "test-app",
+				Profile:     "test-profile",
+				Environment: "test-env",
+				Timeout:     300,
+				Description: tt.description,
+			}
+
+			if err := wf.Run(context.Background(), opts); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			checkDesc := func(label string, got *string) {
+				if tt.wantNil {
+					if got != nil {
+						t.Errorf("%s: expected Description to be nil, got %q", label, *got)
+					}
+					return
+				}
+				if got == nil {
+					t.Errorf("%s: expected Description %q, got nil", label, tt.wantValue)
+					return
+				}
+				if *got != tt.wantValue {
+					t.Errorf("%s: Description = %q, want %q", label, *got, tt.wantValue)
+				}
+			}
+			checkDesc("CreateHostedConfigurationVersion", capturedVersionDesc)
+			checkDesc("StartDeployment", capturedDeploymentDesc)
+		})
+	}
+}

--- a/internal/run/deploy.go
+++ b/internal/run/deploy.go
@@ -119,14 +119,17 @@ func (d *Deployer) CheckOngoingDeployment(ctx context.Context, resolved *aws.Res
 	return d.awsClient.CheckOngoingDeployment(ctx, resolved.ApplicationID, resolved.EnvironmentID)
 }
 
-// CreateVersion creates a new hosted configuration version
-func (d *Deployer) CreateVersion(ctx context.Context, resolved *aws.ResolvedResources, content []byte, contentType string) (int32, error) {
-	return d.awsClient.CreateHostedConfigurationVersion(ctx, resolved.ApplicationID, resolved.Profile.ID, content, contentType, "")
+// CreateVersion creates a new hosted configuration version. The description
+// (when non-empty) is forwarded to AppConfig and shown in the console / on
+// `apcdeploy status`.
+func (d *Deployer) CreateVersion(ctx context.Context, resolved *aws.ResolvedResources, content []byte, contentType, description string) (int32, error) {
+	return d.awsClient.CreateHostedConfigurationVersion(ctx, resolved.ApplicationID, resolved.Profile.ID, content, contentType, description)
 }
 
-// StartDeployment starts a deployment
-func (d *Deployer) StartDeployment(ctx context.Context, resolved *aws.ResolvedResources, versionNumber int32) (int32, error) {
-	return d.awsClient.StartDeployment(ctx, resolved.ApplicationID, resolved.EnvironmentID, resolved.Profile.ID, resolved.DeploymentStrategyID, versionNumber, "")
+// StartDeployment starts a deployment. The description (when non-empty) is
+// forwarded to AppConfig and shown in the console / on `apcdeploy status`.
+func (d *Deployer) StartDeployment(ctx context.Context, resolved *aws.ResolvedResources, versionNumber int32, description string) (int32, error) {
+	return d.awsClient.StartDeployment(ctx, resolved.ApplicationID, resolved.EnvironmentID, resolved.Profile.ID, resolved.DeploymentStrategyID, versionNumber, description)
 }
 
 // WaitForDeploymentPhase waits for a deployment to reach a specific phase.

--- a/internal/run/deploy_test.go
+++ b/internal/run/deploy_test.go
@@ -594,7 +594,7 @@ func TestCreateVersionWithMock(t *testing.T) {
 		},
 	}
 
-	versionNumber, err := deployer.CreateVersion(context.Background(), resolved, []byte(`{"key":"value"}`), "application/json")
+	versionNumber, err := deployer.CreateVersion(context.Background(), resolved, []byte(`{"key":"value"}`), "application/json", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -636,7 +636,7 @@ func TestStartDeploymentWithMock(t *testing.T) {
 		},
 	}
 
-	deploymentNumber, err := deployer.StartDeployment(context.Background(), resolved, 1)
+	deploymentNumber, err := deployer.StartDeployment(context.Background(), resolved, 1, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/run/executor.go
+++ b/internal/run/executor.go
@@ -122,7 +122,7 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 	}
 
 	chk.Start(idxVersion)
-	versionNumber, err := deployer.CreateVersion(ctx, resolved, dataContent, contentType)
+	versionNumber, err := deployer.CreateVersion(ctx, resolved, dataContent, contentType, opts.Description)
 	if err != nil {
 		chk.Fail(idxVersion, "")
 		if aws.IsValidationError(err) {
@@ -133,7 +133,7 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 	chk.Done(idxVersion, fmt.Sprintf("Created configuration version %d", versionNumber))
 
 	chk.Start(idxDeploy)
-	deploymentNumber, err := deployer.StartDeployment(ctx, resolved, versionNumber)
+	deploymentNumber, err := deployer.StartDeployment(ctx, resolved, versionNumber, opts.Description)
 	if err != nil {
 		chk.Fail(idxDeploy, "")
 		return fmt.Errorf("failed to start deployment: %w", err)

--- a/internal/run/options.go
+++ b/internal/run/options.go
@@ -2,9 +2,10 @@ package run
 
 // Options contains the configuration options for deployment
 type Options struct {
-	ConfigFile string
-	WaitDeploy bool
-	WaitBake   bool
-	Timeout    int
-	Force      bool
+	ConfigFile  string
+	WaitDeploy  bool
+	WaitBake    bool
+	Timeout     int
+	Force       bool
+	Description string
 }

--- a/llms.md
+++ b/llms.md
@@ -568,9 +568,7 @@ apcdeploy run -c apcdeploy.yml --wait-bake --timeout 900
 
 # Attach a description to the configuration version and deployment
 apcdeploy run -c apcdeploy.yml --description "hotfix: bump retry limit"
-
-# Tag with the current git commit
-apcdeploy run -c apcdeploy.yml --description "$(git log -1 --pretty='%h %s')"
+apcdeploy run -c apcdeploy.yml --description "ticket-123: tweak feature flag"
 ```
 
 #### Flags

--- a/llms.md
+++ b/llms.md
@@ -565,6 +565,12 @@ apcdeploy run -c apcdeploy.yml --force
 
 # Specify timeout
 apcdeploy run -c apcdeploy.yml --wait-bake --timeout 900
+
+# Attach a description to the configuration version and deployment
+apcdeploy run -c apcdeploy.yml --description "hotfix: bump retry limit"
+
+# Tag with the current git commit
+apcdeploy run -c apcdeploy.yml --description "$(git log -1 --pretty='%h %s')"
 ```
 
 #### Flags
@@ -573,6 +579,7 @@ apcdeploy run -c apcdeploy.yml --wait-bake --timeout 900
 - `--wait-bake`: Wait for complete deployment including baking phase
 - `--force`: Deploy even when content is unchanged
 - `--timeout <seconds>`: Timeout in seconds for deployment wait (default: 1800)
+- `--description <text>`: Description attached to the configuration version and deployment. Visible in the AppConfig console and in `apcdeploy status` output. Defaults to `"Deployed by apcdeploy"` when the flag is omitted, so AppConfig deployments are distinguishable from manual console edits. Pass `--description ""` to clear the description entirely. Maximum 1024 characters (AppConfig API limit); rejected client-side when exceeded.
 
 **Important**: `--wait-deploy` and `--wait-bake` are mutually exclusive and cannot be used together.
 
@@ -1113,6 +1120,9 @@ apcdeploy edit --deployment-strategy AppConfig.Linear
 
 # Wait for baking to complete
 apcdeploy edit --wait-bake --timeout 3900
+
+# Attach a description for traceability
+apcdeploy edit --description "ticket-123: tweak retry limit"
 ```
 
 #### Flags
@@ -1125,6 +1135,7 @@ apcdeploy edit --wait-bake --timeout 3900
 - `--wait-deploy`: Wait for deployment phase to complete (until baking starts)
 - `--wait-bake`: Wait for complete deployment including baking phase
 - `--timeout <seconds>`: Timeout in seconds for deployment wait (default: 1800)
+- `--description <text>`: Description attached to the configuration version and deployment (max 1024 chars). Defaults to `"Deployed by apcdeploy"`; pass `--description ""` to clear it.
 
 **Important**: `--wait-deploy` and `--wait-bake` are mutually exclusive.
 


### PR DESCRIPTION
## Summary

- Add `--description <text>` flag to `apcdeploy run` and `apcdeploy edit`. The value is forwarded to AppConfig's `CreateHostedConfigurationVersion.Description` and `StartDeployment.Description`, surfacing in the AppConfig console and `apcdeploy status`.
- Default to `"Deployed by apcdeploy"` when the flag is omitted, so deployments authored by this CLI are distinguishable from manual console edits. Explicit `--description ""` opts out of the default.
- Validate the value client-side at 1024 Unicode runes (the AppConfig API limit) so oversized input fails before any AWS round-trip.

Closes #75.

## Notes

- Earlier iterations of this PR included a `--commit-info` flag and an `internal/git` package; both were dropped after the convenience didn't justify the code/test surface. Users who want commit-tagged deployments can do `--description \"\$(git log -1 --pretty='%h %s')\"`.
- Validation counts runes (not bytes) so multibyte input (e.g. Japanese) is not over-rejected. Tested on the boundary for both ASCII and multibyte.

## Test plan

- [x] `mise run ci` passes (coverage 90.2%)
- [x] `go test -shuffle=on ./cmd/` passes (no global-state ordering bugs)
- [x] `mise run e2e-full` — full E2E suite (S1-S8 + E1-E5) passes against real AWS resources, including new S8 covering: default value, explicit value, opt-out, 1024-rune validation, edit-via-`\$EDITOR` description forwarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)