### PR TITLE
feat: multi-config support for run/diff/pull (PR-2)

### DIFF
--- a/.claude/rules/output-contract.md
+++ b/.claude/rules/output-contract.md
@@ -159,8 +159,54 @@ need to see this risk even when they otherwise want machine-readable output.
 Routing through `Reporter.Warn` would suppress it under `--silent`, so the
 notice bypasses the Reporter for this single case.
 
-This is the only sanctioned bypass. New callers must not introduce more
-without adding a similar entry here.
+### Multi-config aggregate summary and Errors section
+
+`cmd/batch_render.go::renderBatchSummary` writes the post-run aggregate
+line (`N ok, N no-op, N failed [(elapsed)]` per `docs/design/output.md`
+§8.2) and the `Errors:` section (§8.3) directly to `os.Stderr` instead
+of routing through Reporter.
+
+Why: Reporter has no "plain stderr line" primitive — `Header` / `Box` /
+`Info` would over-format these short lines. The renderer honours
+`--silent` itself by checking `isSilent()` before writing, so the
+behaviour matches the rest of the silent-mode contract; only the
+mechanism (direct `os.Stderr`) differs. Any new caller adding a
+similar bare-line summary must extend `batch_render.go` rather than
+sprinkling `fmt.Fprint*` calls in cmd files.
+
+These two are the only sanctioned bypasses. New callers must not
+introduce more without adding a similar entry here.
+
+## Multi-config orchestration
+
+`run`, `diff`, and `pull` accept `-c` repeatedly (see
+`docs/design/multi-config.md`). The plumbing lives in `internal/batch`:
+
+- `batch.LoadAll(paths)` pre-loads and validates every `-c` before any
+  AWS work; load failures abort the batch as a single "事前エラー"
+  (multi-config.md §10.1).
+- `batch.Orchestrator` opens a single `Reporter.Targets` handle for all
+  rows, drives executor callbacks in argument order under a worker
+  pool, and aggregates per-target outcomes into `batch.Summary`.
+- Per-target callbacks receive `reporter.TargetReporter` (a single-row
+  view returned by `batch.NewTargetReporter`) so they don't carry
+  their own identifier.
+
+Each executor exposes both `Execute(ctx, opts)` (single-config) and
+`RunOnTarget(ctx, *batch.Target, reporter.TargetReporter, ...)`
+(orchestrator entry point). Both delegate to a shared
+`runOnTargetWith*` body so visual output is bit-identical between the
+two paths. `cmd/{run,diff,pull}.go` dispatch on
+`len(configFiles)`: single-config keeps the existing `Execute` path
+(so the row identifier still shows the SDK-resolved default region
+when `cfg.Region` is empty); multi-config flows through
+`batch.Orchestrator` and requires region in yml
+(multi-config.md §6.2).
+
+Failed targets are surfaced both as `Targets.Fail` rows (during the
+run) and as `Errors:` entries in the post-run section (after Close).
+Resolution hints come from `internal/errors.Resolution`, exactly like
+single-target callers — see "Resolution hints" below.
 
 ## What MUST NOT happen
 

--- a/.claude/rules/output-contract.md
+++ b/.claude/rules/output-contract.md
@@ -8,9 +8,8 @@ The contract is enforced by the `internal/reporter` interface and its
 `internal/cli` implementations. Executors MUST NOT call `fmt.Fprint*` directly;
 all output flows through the `Reporter`.
 
-The visual model and per-command screen designs live in
-`docs/design/output.md`. This file is the implementation-level contract — the
-"rules" — while `output.md` is the "picture".
+This file is the implementation-level contract — the "rules" for how
+commands produce output.
 
 ## Channels
 
@@ -45,13 +44,12 @@ silent-mode behavior, and visual treatment.
 | `Data(p []byte)` | **stdout** | **always shown** | none | Machine-readable payload |
 | `Diff(p []byte)` | **stdout** | **always shown** | colorized when TTY | Unified diff payload |
 
-`Targets` is the primary primitive (see `docs/design/output.md` §4). Every
-deployment-target command tracks its lifecycle through a `Targets` block where
-each `id` is one row and the row's state icon, phase label, and optional
-progress bar are driven from the executor. `Step` / `Success` / `Info` /
-`Spin` are retained only for `init`, which is fundamentally a sequential
-interactive workflow that does not fit the target-centric model
-(`docs/design/output.md` §11 Q-1).
+`Targets` is the primary primitive. Every deployment-target command tracks
+its lifecycle through a `Targets` block where each `id` is one row and the
+row's state icon, phase label, and optional progress bar are driven from
+the executor. `Step` / `Success` / `Info` / `Spin` are retained only for
+`init`, which is fundamentally a sequential interactive workflow that does
+not fit the target-centric model.
 
 `Targets` is `interface { SetPhase(id, phase, detail string); SetProgress(id
 string, percent float64, eta time.Duration); Done(id, summary string);
@@ -70,7 +68,7 @@ emits a `Success`-equivalent line; `Fail` emits an `Error`-equivalent line;
 
 ## Phases and state icons (Targets)
 
-Each Targets row progresses through these states (`docs/design/output.md` §3):
+Each Targets row progresses through these states:
 
 | State | Icon | Color | Meaning |
 |---|---|---|---|
@@ -82,8 +80,7 @@ Each Targets row progresses through these states (`docs/design/output.md` §3):
 | skipped | `→` | dim | terminal early-exit / no-op (`Targets.Skip`) |
 
 Phase verbs are limited to: `preparing`, `comparing`, `creating-version`,
-`deploying`, `baking`, `fetching`, `stopping`. New verbs require an entry in
-`output.md` §3.2.
+`deploying`, `baking`, `fetching`, `stopping`.
 
 ## Confirmations
 
@@ -162,9 +159,8 @@ notice bypasses the Reporter for this single case.
 ### Multi-config aggregate summary and Errors section
 
 `cmd/batch_render.go::renderBatchSummary` writes the post-run aggregate
-line (`N ok, N no-op, N failed [(elapsed)]` per `docs/design/output.md`
-§8.2) and the `Errors:` section (§8.3) directly to `os.Stderr` instead
-of routing through Reporter.
+line (`N ok, N no-op, N failed [(elapsed)]`) and the `Errors:` section
+directly to `os.Stderr` instead of routing through Reporter.
 
 Why: Reporter has no "plain stderr line" primitive — `Header` / `Box` /
 `Info` would over-format these short lines. The renderer honours
@@ -179,12 +175,11 @@ introduce more without adding a similar entry here.
 
 ## Multi-config orchestration
 
-`run`, `diff`, and `pull` accept `-c` repeatedly (see
-`docs/design/multi-config.md`). The plumbing lives in `internal/batch`:
+`run`, `diff`, and `pull` accept `-c` repeatedly. The plumbing lives in
+`internal/batch`:
 
 - `batch.LoadAll(paths)` pre-loads and validates every `-c` before any
-  AWS work; load failures abort the batch as a single "事前エラー"
-  (multi-config.md §10.1).
+  AWS work; load failures abort the batch before any AWS call is made.
 - `batch.Orchestrator` opens a single `Reporter.Targets` handle for all
   rows, drives executor callbacks in argument order under a worker
   pool, and aggregates per-target outcomes into `batch.Summary`.
@@ -200,8 +195,7 @@ two paths. `cmd/{run,diff,pull}.go` dispatch on
 `len(configFiles)`: single-config keeps the existing `Execute` path
 (so the row identifier still shows the SDK-resolved default region
 when `cfg.Region` is empty); multi-config flows through
-`batch.Orchestrator` and requires region in yml
-(multi-config.md §6.2).
+`batch.Orchestrator` and requires region in yml.
 
 Failed targets are surfaced both as `Targets.Fail` rows (during the
 run) and as `Errors:` entries in the post-run section (after Close).
@@ -249,5 +243,4 @@ short user-facing remediation hint (e.g. "wait for the current deployment to
 complete or run 'apcdeploy rollback'"). Hints exist only for the small set of
 AWS error codes documented in `internal/errors/resolution.go`; callers MUST
 NOT invent new hints inline. To add a hint, add an entry to
-`resolutionHints` and document the rationale in
-`docs/design/output.md` §8.3.
+`resolutionHints`.

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ apcdeploy.yml
 data.json
 data.yaml
 data.txt
+
+docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,14 +179,14 @@ Edit command implementation:
 
 #### internal/batch
 
-Multi-config orchestration for `run` / `diff` / `pull` (designed in `docs/design/multi-config.md`):
+Multi-config orchestration for `run` / `diff` / `pull`:
 
 - `target.go`: `Target` struct (`Path`, `Config`, `Identifier`) — one loaded `-c` argument
 - `loader.go`: `LoadAll(paths)` pre-loads and validates every config before any AWS work, deduplicates equivalent paths (`./x.yml` vs `x.yml`), and surfaces identifier collisions (`region/app/profile/env` 4-tuple) with `ErrDuplicateTarget`
 - `orchestrator.go`: worker-pool driver with FIFO start order, optional `Parallel` limit (default = `len(targets)`), fail-fast (queued targets get `Skip("skipped (fail-fast)")` without cancelling in-flight ones) or `ContinueOnError`. Returns a `Summary` (OK / NoOp / Skipped / Failed counts + `[]TargetError` for the post-run "Errors:" section)
 - `NewTargetReporter(tg, id)`: wraps a single row of an existing `Targets` handle so single-target executor entry points can share their per-target body with the orchestrator path
 
-Each executor exposes both `Execute(ctx, opts)` (single-config) and `RunOnTarget(ctx, *batch.Target, reporter.TargetReporter, ...)` (orchestrator entry point); both delegate to a shared `runOnTargetWith*` body so the per-target output is bit-identical between paths. `cmd/run.go` / `cmd/diff.go` / `cmd/pull.go` dispatch on `len(configFiles)` — single-config keeps the existing path (so the row identifier still shows the SDK-resolved default region when `cfg.Region` is empty); multi-config goes through the orchestrator and requires region in yml (multi-config.md §6.2).
+Each executor exposes both `Execute(ctx, opts)` (single-config) and `RunOnTarget(ctx, *batch.Target, reporter.TargetReporter, ...)` (orchestrator entry point); both delegate to a shared `runOnTargetWith*` body so the per-target output is bit-identical between paths. `cmd/run.go` / `cmd/diff.go` / `cmd/pull.go` dispatch on `len(configFiles)` — single-config keeps the existing path (so the row identifier still shows the SDK-resolved default region when `cfg.Region` is empty); multi-config goes through the orchestrator and requires region in yml.
 
 #### internal/lsresources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,11 @@ Dev tools (Go toolchain, golangci-lint, gofumpt, tparse, octocov, goreleaser, te
 ./apcdeploy ls-resources --region us-east-1 --json --silent  # silent without --json yields no stdout
 ./apcdeploy diff -c apcdeploy.yml --silent
 ./apcdeploy status -c apcdeploy.yml --silent
+
+# Multi-config (run / diff / pull): pass -c repeatedly
+./apcdeploy diff -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml
+./apcdeploy run  -c environments/*.yml --parallel 3 --wait-bake
+./apcdeploy pull -c environments/*.yml --continue-on-error
 ```
 
 ### E2E Testing
@@ -171,6 +176,17 @@ Edit command implementation:
 - No configuration file required; operates independently of `apcdeploy.yml`
 - Validation parity with `run`: same size limit and JSON/YAML syntax checks
 - Deployment strategy defaults to the strategy of the most recent deployment when `--deployment-strategy` is omitted
+
+#### internal/batch
+
+Multi-config orchestration for `run` / `diff` / `pull` (designed in `docs/design/multi-config.md`):
+
+- `target.go`: `Target` struct (`Path`, `Config`, `Identifier`) — one loaded `-c` argument
+- `loader.go`: `LoadAll(paths)` pre-loads and validates every config before any AWS work, deduplicates equivalent paths (`./x.yml` vs `x.yml`), and surfaces identifier collisions (`region/app/profile/env` 4-tuple) with `ErrDuplicateTarget`
+- `orchestrator.go`: worker-pool driver with FIFO start order, optional `Parallel` limit (default = `len(targets)`), fail-fast (queued targets get `Skip("skipped (fail-fast)")` without cancelling in-flight ones) or `ContinueOnError`. Returns a `Summary` (OK / NoOp / Skipped / Failed counts + `[]TargetError` for the post-run "Errors:" section)
+- `NewTargetReporter(tg, id)`: wraps a single row of an existing `Targets` handle so single-target executor entry points can share their per-target body with the orchestrator path
+
+Each executor exposes both `Execute(ctx, opts)` (single-config) and `RunOnTarget(ctx, *batch.Target, reporter.TargetReporter, ...)` (orchestrator entry point); both delegate to a shared `runOnTargetWith*` body so the per-target output is bit-identical between paths. `cmd/run.go` / `cmd/diff.go` / `cmd/pull.go` dispatch on `len(configFiles)` — single-config keeps the existing path (so the row identifier still shows the SDK-resolved default region when `cfg.Region` is empty); multi-config goes through the orchestrator and requires region in yml (multi-config.md §6.2).
 
 #### internal/lsresources
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ For detailed usage information and advanced features, see [llms.md](./llms.md).
 
 All commands support these global flags:
 
-- `-c, --config`: Config file path (default: `apcdeploy.yml`)
+- `-c, --config`: Config file path (default: `apcdeploy.yml`). May be passed multiple times for `run` / `diff` / `pull` to operate on several configs in one invocation
 - `-s, --silent`: Suppress verbose output, show only essential information (useful for CI/CD and scripting)
 
 ### ls-resources
@@ -246,13 +246,21 @@ Deploy configuration changes:
 apcdeploy run -c apcdeploy.yml [--wait-deploy|--wait-bake] [--force]
 ```
 
+Pass `-c` multiple times to deploy several configs in one invocation:
+
+```bash
+apcdeploy run -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml --wait-bake
+```
+
 Options:
 
 - `--wait-deploy`: Wait for deployment phase to complete (until baking starts)
 - `--wait-bake`: Wait for complete deployment including baking phase
-- `--timeout`: Timeout in seconds for deployment wait (default: 1800)
+- `--timeout`: Per-target timeout in seconds for deployment wait (default: 1800)
 - `--force`: Deploy even if content hasn't changed
 - `--description`: Description attached to the configuration version and deployment (max 1024 chars). Defaults to `"Deployed by apcdeploy"`; pass `--description ""` to clear it.
+- `--parallel`: Maximum concurrent targets when `-c` is repeated (default: all in parallel)
+- `--continue-on-error`: Run remaining targets after one fails (default: fail-fast)
 
 Note: `--wait-deploy` and `--wait-bake` are mutually exclusive.
 
@@ -292,9 +300,17 @@ Preview configuration changes:
 apcdeploy diff -c apcdeploy.yml [--exit-nonzero]
 ```
 
+Pass `-c` multiple times to diff several configs in one invocation. Each target's diff is prefixed with `=== <region>/<app>/<profile>/<env> ===`; the single-target form omits the header so it can be piped into `patch` / `git apply`.
+
+```bash
+apcdeploy diff -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml
+```
+
 Options:
 
 - `--exit-nonzero`: Exit with code 1 if differences are found (useful in CI)
+- `--parallel`: Maximum concurrent targets when `-c` is repeated (default: all in parallel)
+- `--continue-on-error`: Run remaining targets after one fails (default: fail-fast)
 
 ### status
 
@@ -325,6 +341,17 @@ Pull the latest deployed configuration and update your local data file:
 ```bash
 apcdeploy pull -c apcdeploy.yml
 ```
+
+Pass `-c` multiple times to pull several configurations in one invocation:
+
+```bash
+apcdeploy pull -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml
+```
+
+Options:
+
+- `--parallel`: Maximum concurrent targets when `-c` is repeated (default: all in parallel)
+- `--continue-on-error`: Run remaining targets after one fails (default: fail-fast)
 
 This command is useful when configuration changes are made directly in the AWS Console and you want to sync your local files with the deployed state.
 

--- a/cmd/batch_render.go
+++ b/cmd/batch_render.go
@@ -7,7 +7,6 @@ import (
 	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/cli"
 	apcerrors "github.com/koh-sh/apcdeploy/internal/errors"
-	"github.com/koh-sh/apcdeploy/internal/reporter"
 )
 
 // summaryConfig describes how to render a batch.Summary line for one
@@ -36,7 +35,7 @@ type summaryConfig struct {
 // The Errors: section is also suppressed because failed targets are
 // already surfaced through Targets.Fail before this point and through
 // the top-level Error in cmd/root.go.
-func renderBatchSummary(_ reporter.Reporter, summary batch.Summary, n int, cfg summaryConfig) {
+func renderBatchSummary(summary batch.Summary, n int, cfg summaryConfig) {
 	if isSilent() {
 		return
 	}

--- a/cmd/batch_render.go
+++ b/cmd/batch_render.go
@@ -11,31 +11,31 @@ import (
 )
 
 // summaryConfig describes how to render a batch.Summary line for one
-// command. The aggregate format is fixed by docs/design/output.md §8.2:
+// command. The aggregate format is:
 //
 //	N ok, N <noopVerb>, N failed [(elapsed)]
 //
 // withElapsed controls whether the trailing "(elapsed)" suffix appears.
-// Per the design only wait-style commands (run with --wait-deploy /
-// --wait-bake) include it; diff and pull omit it because their elapsed
-// time is dominated by network I/O and would be misleading as a metric.
+// Only wait-style commands (run with --wait-deploy / --wait-bake) include
+// it; diff and pull omit it because their elapsed time is dominated by
+// network I/O and would be misleading as a metric.
 type summaryConfig struct {
 	noopVerb    string
 	withElapsed bool
 }
 
 // renderBatchSummary writes the aggregate summary line plus, when there
-// were failures, the per-target Errors: section described in
-// docs/design/output.md §8.3. The summary is only shown when N >= 2
-// (single-target output already terminates in the row's Done/Skip/Fail
-// line; an additional summary would be noisy). Both lines go directly
-// to os.Stderr — Reporter has no "plain stderr line" primitive, and
-// using Header/Box/Info would over-format the bare summary.
+// were failures, the per-target Errors: section. The summary is only
+// shown when N >= 2 (single-target output already terminates in the
+// row's Done/Skip/Fail line; an additional summary would be noisy).
+// Both lines go directly to os.Stderr — Reporter has no "plain stderr
+// line" primitive, and using Header/Box/Info would over-format the bare
+// summary.
 //
-// Suppressed under --silent to match the rest of stderr summary output
-// (docs/design/output.md §6.3). The Errors: section is also suppressed
-// because failed targets are already surfaced through Targets.Fail
-// before this point and through the top-level Error in cmd/root.go.
+// Suppressed under --silent to match the rest of stderr summary output.
+// The Errors: section is also suppressed because failed targets are
+// already surfaced through Targets.Fail before this point and through
+// the top-level Error in cmd/root.go.
 func renderBatchSummary(_ reporter.Reporter, summary batch.Summary, n int, cfg summaryConfig) {
 	if isSilent() {
 		return
@@ -56,7 +56,7 @@ func renderBatchSummary(_ reporter.Reporter, summary batch.Summary, n int, cfg s
 
 // renderErrorsSection prints the Errors: block beneath the summary when
 // any target failed. Resolution hints come from internal/errors so the
-// list stays curated (output.md §8.3); unknown error types omit the
+// list stays curated; unknown error types omit the
 // Resolution line entirely. Caller is responsible for honouring
 // --silent — this helper does not check.
 func renderErrorsSection(summary batch.Summary) {

--- a/cmd/batch_render.go
+++ b/cmd/batch_render.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/koh-sh/apcdeploy/internal/batch"
+	"github.com/koh-sh/apcdeploy/internal/cli"
+	apcerrors "github.com/koh-sh/apcdeploy/internal/errors"
+	"github.com/koh-sh/apcdeploy/internal/reporter"
+)
+
+// summaryConfig describes how to render a batch.Summary line for one
+// command. The aggregate format is fixed by docs/design/output.md §8.2:
+//
+//	N ok, N <noopVerb>, N failed [(elapsed)]
+//
+// withElapsed controls whether the trailing "(elapsed)" suffix appears.
+// Per the design only wait-style commands (run with --wait-deploy /
+// --wait-bake) include it; diff and pull omit it because their elapsed
+// time is dominated by network I/O and would be misleading as a metric.
+type summaryConfig struct {
+	noopVerb    string
+	withElapsed bool
+}
+
+// renderBatchSummary writes the aggregate summary line plus, when there
+// were failures, the per-target Errors: section described in
+// docs/design/output.md §8.3. The summary is only shown when N >= 2
+// (single-target output already terminates in the row's Done/Skip/Fail
+// line; an additional summary would be noisy). Both lines go directly
+// to os.Stderr — Reporter has no "plain stderr line" primitive, and
+// using Header/Box/Info would over-format the bare summary.
+//
+// Suppressed under --silent to match the rest of stderr summary output
+// (docs/design/output.md §6.3). The Errors: section is also suppressed
+// because failed targets are already surfaced through Targets.Fail
+// before this point and through the top-level Error in cmd/root.go.
+func renderBatchSummary(_ reporter.Reporter, summary batch.Summary, n int, cfg summaryConfig) {
+	if isSilent() {
+		return
+	}
+	if n < 2 {
+		renderErrorsSection(summary)
+		return
+	}
+	noOp := summary.NoOp + summary.Skipped
+	line := fmt.Sprintf("%d ok, %d %s, %d failed", summary.OK, noOp, cfg.noopVerb, summary.Failed)
+	if cfg.withElapsed && summary.Elapsed > 0 {
+		line += " (" + cli.FormatElapsed(summary.Elapsed) + ")"
+	}
+	_, _ = fmt.Fprintln(os.Stderr)
+	_, _ = fmt.Fprintln(os.Stderr, line)
+	renderErrorsSection(summary)
+}
+
+// renderErrorsSection prints the Errors: block beneath the summary when
+// any target failed. Resolution hints come from internal/errors so the
+// list stays curated (output.md §8.3); unknown error types omit the
+// Resolution line entirely. Caller is responsible for honouring
+// --silent — this helper does not check.
+func renderErrorsSection(summary batch.Summary) {
+	if len(summary.Errors) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(os.Stderr)
+	_, _ = fmt.Fprintln(os.Stderr, "Errors:")
+	for _, e := range summary.Errors {
+		_, _ = fmt.Fprintln(os.Stderr, "  "+e.Identifier)
+		_, _ = fmt.Fprintln(os.Stderr, "    "+e.Err.Error())
+		if hint := apcerrors.Resolution(e.Err); hint != "" {
+			_, _ = fmt.Fprintln(os.Stderr, "    Resolution: "+hint)
+		}
+	}
+}

--- a/cmd/batch_render_test.go
+++ b/cmd/batch_render_test.go
@@ -80,9 +80,9 @@ func TestRenderBatchSummary_SkippedFoldedIntoNoOp(t *testing.T) {
 	silent = false
 	t.Cleanup(func() { silent = false })
 
-	// Fail-fast skip is "no-op" from the user's perspective (output.md
-	// §8.2): the target didn't change anything because the batch
-	// short-circuited it. Counter 2 (NoOp) collapses NoOp + Skipped.
+	// Fail-fast skip is "no-op" from the user's perspective: the target
+	// didn't change anything because the batch short-circuited it.
+	// Counter 2 (NoOp) collapses NoOp + Skipped.
 	out := captureStderr(t, func() {
 		renderBatchSummary(&reportertest.MockReporter{},
 			batch.Summary{OK: 1, NoOp: 1, Skipped: 1, Failed: 1},

--- a/cmd/batch_render_test.go
+++ b/cmd/batch_render_test.go
@@ -1,0 +1,235 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/koh-sh/apcdeploy/internal/batch"
+	reportertest "github.com/koh-sh/apcdeploy/internal/reporter/testing"
+)
+
+// captureStderr swaps os.Stderr for a pipe, runs fn, and returns the
+// captured bytes. Used by the batch render tests because the helpers
+// write directly to os.Stderr (no Reporter primitive carries plain
+// summary lines — see batch_render.go for the rationale).
+//
+// Tests run sequentially around the swap because os.Stderr is process
+// global; callers must not use t.Parallel().
+var captureMu sync.Mutex
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	captureMu.Lock()
+	defer captureMu.Unlock()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+
+	done := make(chan []byte, 1)
+	go func() {
+		buf, _ := io.ReadAll(r)
+		done <- buf
+	}()
+
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+
+	return string(<-done)
+}
+
+func TestRenderBatchSummary_HiddenForSingleTarget(t *testing.T) {
+	silent = false
+	t.Cleanup(func() { silent = false })
+
+	out := captureStderr(t, func() {
+		renderBatchSummary(&reportertest.MockReporter{}, batch.Summary{OK: 1}, 1, summaryConfig{noopVerb: "no-op"})
+	})
+	if out != "" {
+		t.Errorf("N=1 should not emit a summary line; got %q", out)
+	}
+}
+
+func TestRenderBatchSummary_RendersForMultipleTargets(t *testing.T) {
+	silent = false
+	t.Cleanup(func() { silent = false })
+
+	out := captureStderr(t, func() {
+		renderBatchSummary(&reportertest.MockReporter{},
+			batch.Summary{OK: 2, NoOp: 1, Failed: 0, Elapsed: 12 * time.Second},
+			3,
+			summaryConfig{noopVerb: "no-op", withElapsed: true},
+		)
+	})
+	if !strings.Contains(out, "2 ok, 1 no-op, 0 failed (12s)") {
+		t.Errorf("summary missing expected counts/elapsed; got %q", out)
+	}
+}
+
+func TestRenderBatchSummary_SkippedFoldedIntoNoOp(t *testing.T) {
+	silent = false
+	t.Cleanup(func() { silent = false })
+
+	// Fail-fast skip is "no-op" from the user's perspective (output.md
+	// §8.2): the target didn't change anything because the batch
+	// short-circuited it. Counter 2 (NoOp) collapses NoOp + Skipped.
+	out := captureStderr(t, func() {
+		renderBatchSummary(&reportertest.MockReporter{},
+			batch.Summary{OK: 1, NoOp: 1, Skipped: 1, Failed: 1},
+			4,
+			summaryConfig{noopVerb: "no-op"},
+		)
+	})
+	if !strings.Contains(out, "1 ok, 2 no-op, 1 failed") {
+		t.Errorf("Skipped should fold into no-op count; got %q", out)
+	}
+}
+
+func TestRenderBatchSummary_SilentSuppresses(t *testing.T) {
+	silent = true
+	t.Cleanup(func() { silent = false })
+
+	out := captureStderr(t, func() {
+		renderBatchSummary(&reportertest.MockReporter{},
+			batch.Summary{OK: 2, Failed: 1, Errors: []batch.TargetError{
+				{Identifier: "us-east-1/a/b/c", Err: errors.New("boom")},
+			}},
+			3,
+			summaryConfig{noopVerb: "no-op"},
+		)
+	})
+	if out != "" {
+		t.Errorf("--silent must suppress everything; got %q", out)
+	}
+}
+
+func TestRenderBatchSummary_ErrorsSection(t *testing.T) {
+	silent = false
+	t.Cleanup(func() { silent = false })
+
+	out := captureStderr(t, func() {
+		renderBatchSummary(&reportertest.MockReporter{},
+			batch.Summary{OK: 1, Failed: 1, Errors: []batch.TargetError{
+				{Identifier: "us-east-1/a/b/c", Err: errors.New("boom")},
+			}},
+			2,
+			summaryConfig{noopVerb: "no-op"},
+		)
+	})
+	for _, want := range []string{"Errors:", "us-east-1/a/b/c", "boom"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Errors: section missing %q; got %q", want, out)
+		}
+	}
+}
+
+func TestRenderErrorsSection_NoOpWhenEmpty(t *testing.T) {
+	out := captureStderr(t, func() {
+		renderErrorsSection(batch.Summary{OK: 3})
+	})
+	if out != "" {
+		t.Errorf("no failures should yield no Errors: section; got %q", out)
+	}
+}
+
+// Sanity: the captureStderr helper itself works (smoke).
+func TestCaptureStderr_Smoke(t *testing.T) {
+	out := captureStderr(t, func() {
+		_, _ = os.Stderr.Write([]byte("hello"))
+	})
+	if !bytes.Equal([]byte(out), []byte("hello")) {
+		t.Errorf("captureStderr round-trip = %q, want %q", out, "hello")
+	}
+}
+
+func TestRequireSingleConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []string
+		wantOK bool
+		want   string
+		errSub string
+	}{
+		{"empty defaults to apcdeploy.yml", nil, true, defaultConfigFile, ""},
+		{"single value passes through", []string{"my.yml"}, true, "my.yml", ""},
+		{"two values rejected", []string{"a.yml", "b.yml"}, false, "", "does not support multiple"},
+		{"three values rejected", []string{"a.yml", "b.yml", "c.yml"}, false, "", "got 3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configFiles = tt.input
+			t.Cleanup(func() { configFiles = []string{defaultConfigFile} })
+			got, err := requireSingleConfig("test")
+			if tt.wantOK {
+				if err != nil {
+					t.Fatalf("err = %v, want nil", err)
+				}
+				if got != tt.want {
+					t.Errorf("path = %q, want %q", got, tt.want)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("err = nil, want error")
+				}
+				if !strings.Contains(err.Error(), tt.errSub) {
+					t.Errorf("err = %q, want substring %q", err.Error(), tt.errSub)
+				}
+			}
+		})
+	}
+}
+
+func TestFlushDiffPayloads(t *testing.T) {
+	tests := []struct {
+		name     string
+		targets  []*batch.Target
+		payloads [][]byte
+		want     string
+	}{
+		{
+			name: "skips empty payloads",
+			targets: []*batch.Target{
+				{Identifier: "us-east-1/a/b/dev"},
+				{Identifier: "us-east-1/a/b/stg"},
+				{Identifier: "us-east-1/a/b/prod"},
+			},
+			payloads: [][]byte{
+				nil,
+				[]byte("--- a\n+++ b\n@@ -1 +1 @@\n-x\n+y\n"),
+				nil,
+			},
+			want: "=== us-east-1/a/b/stg ===\n--- a\n+++ b\n@@ -1 +1 @@\n-x\n+y\n",
+		},
+		{
+			name: "headers each non-empty payload in argument order with blank-line separator",
+			targets: []*batch.Target{
+				{Identifier: "id-A"},
+				{Identifier: "id-B"},
+			},
+			payloads: [][]byte{
+				[]byte("diff-A\n"),
+				[]byte("diff-B\n"),
+			},
+			want: "=== id-A ===\ndiff-A\n\n=== id-B ===\ndiff-B\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rep := &reportertest.MockReporter{}
+			flushDiffPayloads(rep, tt.targets, tt.payloads)
+			if got := string(rep.Stdout); got != tt.want {
+				t.Errorf("stdout = %q\nwant   %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/batch_render_test.go
+++ b/cmd/batch_render_test.go
@@ -53,7 +53,7 @@ func TestRenderBatchSummary_HiddenForSingleTarget(t *testing.T) {
 	t.Cleanup(func() { silent = false })
 
 	out := captureStderr(t, func() {
-		renderBatchSummary(&reportertest.MockReporter{}, batch.Summary{OK: 1}, 1, summaryConfig{noopVerb: "no-op"})
+		renderBatchSummary(batch.Summary{OK: 1}, 1, summaryConfig{noopVerb: "no-op"})
 	})
 	if out != "" {
 		t.Errorf("N=1 should not emit a summary line; got %q", out)
@@ -65,7 +65,7 @@ func TestRenderBatchSummary_RendersForMultipleTargets(t *testing.T) {
 	t.Cleanup(func() { silent = false })
 
 	out := captureStderr(t, func() {
-		renderBatchSummary(&reportertest.MockReporter{},
+		renderBatchSummary(
 			batch.Summary{OK: 2, NoOp: 1, Failed: 0, Elapsed: 12 * time.Second},
 			3,
 			summaryConfig{noopVerb: "no-op", withElapsed: true},
@@ -84,7 +84,7 @@ func TestRenderBatchSummary_SkippedFoldedIntoNoOp(t *testing.T) {
 	// didn't change anything because the batch short-circuited it.
 	// Counter 2 (NoOp) collapses NoOp + Skipped.
 	out := captureStderr(t, func() {
-		renderBatchSummary(&reportertest.MockReporter{},
+		renderBatchSummary(
 			batch.Summary{OK: 1, NoOp: 1, Skipped: 1, Failed: 1},
 			4,
 			summaryConfig{noopVerb: "no-op"},
@@ -100,7 +100,7 @@ func TestRenderBatchSummary_SilentSuppresses(t *testing.T) {
 	t.Cleanup(func() { silent = false })
 
 	out := captureStderr(t, func() {
-		renderBatchSummary(&reportertest.MockReporter{},
+		renderBatchSummary(
 			batch.Summary{OK: 2, Failed: 1, Errors: []batch.TargetError{
 				{Identifier: "us-east-1/a/b/c", Err: errors.New("boom")},
 			}},
@@ -118,7 +118,7 @@ func TestRenderBatchSummary_ErrorsSection(t *testing.T) {
 	t.Cleanup(func() { silent = false })
 
 	out := captureStderr(t, func() {
-		renderBatchSummary(&reportertest.MockReporter{},
+		renderBatchSummary(
 			batch.Summary{OK: 1, Failed: 1, Errors: []batch.TargetError{
 				{Identifier: "us-east-1/a/b/c", Err: errors.New("boom")},
 			}},

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSetLLMsContent(t *testing.T) {
+	prev := llmsContent
+	t.Cleanup(func() { llmsContent = prev })
+
+	SetLLMsContent("hello-llms")
+	if llmsContent != "hello-llms" {
+		t.Errorf("llmsContent = %q, want %q", llmsContent, "hello-llms")
+	}
+}
+
+func TestContextCommand_OutputsLLMsContent(t *testing.T) {
+	prev := llmsContent
+	t.Cleanup(func() { llmsContent = prev })
+
+	SetLLMsContent("# llms\n")
+	cmd := ContextCommand()
+
+	// fmt.Print writes to stdout, which Cobra does not redirect via
+	// SetOut. We verify the command runs without error and that
+	// llmsContent is set; capturing stdout would need pipe wiring that
+	// isn't worth the maintenance burden for a one-line command.
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("Execute: %v", err)
+	}
+}
+
+func TestSetVersionInfo(t *testing.T) {
+	pv, pc, pd := version, commit, date
+	t.Cleanup(func() {
+		version, commit, date = pv, pc, pd
+	})
+
+	SetVersionInfo("1.2.3", "abc123", "2026-05-04")
+	if version != "1.2.3" || commit != "abc123" || date != "2026-05-04" {
+		t.Errorf("SetVersionInfo: got version=%q commit=%q date=%q",
+			version, commit, date)
+	}
+}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -3,14 +3,22 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	"sync"
 
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/cli"
 	"github.com/koh-sh/apcdeploy/internal/diff"
+	"github.com/koh-sh/apcdeploy/internal/reporter"
 	"github.com/spf13/cobra"
 )
 
-var diffExitNonzero bool
+var (
+	diffExitNonzero     bool
+	diffParallel        int
+	diffContinueOnError bool
+)
 
 // DiffCommand returns the diff command
 func DiffCommand() *cobra.Command {
@@ -24,44 +32,117 @@ func newDiffCmd() *cobra.Command {
 		Long: `Show differences between local configuration and the currently deployed configuration in AWS AppConfig.
 
 This command compares your local configuration file with the latest deployed version
-and displays the differences in unified diff format.`,
+and displays the differences in unified diff format.
+
+Pass -c multiple times to diff several configurations in one invocation
+(see docs/design/multi-config.md). Multi-target diffs prefix each body
+with "=== <region>/<app>/<profile>/<env> ===" so the combined stream
+stays unambiguous; single-target output omits the header so it can be
+piped into patch/git apply.`,
 		RunE:         runDiff,
 		SilenceUsage: true, // Don't show usage on runtime errors
 	}
 
 	cmd.Flags().BoolVar(&diffExitNonzero, "exit-nonzero", false, "Exit with code 1 if differences exist")
+	cmd.Flags().IntVar(&diffParallel, "parallel", 0, "Maximum concurrent targets when -c is repeated (0 = all in parallel)")
+	cmd.Flags().BoolVar(&diffContinueOnError, "continue-on-error", false, "Run remaining targets after one fails (default: fail-fast)")
 
 	return cmd
 }
 
 func runDiff(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
+	rep := cli.GetReporter(isSilent())
 
-	// TODO(multi-config PR-2 next phase): drop requireSingleConfig and route
-	// through batch.Orchestrator so `-c` may be repeated.
-	cfgFile, err := requireSingleConfig("diff")
-	if err != nil {
+	// Single-config keeps the existing path so the row identifier still
+	// shows the SDK-resolved default region when cfg.Region is empty
+	// (multi-config requires region in yml — multi-config.md §6.2).
+	if len(configFiles) <= 1 {
+		path := defaultConfigFile
+		if len(configFiles) == 1 {
+			path = configFiles[0]
+		}
+		opts := &diff.Options{
+			ConfigFile:  path,
+			ExitNonzero: diffExitNonzero,
+			Silent:      isSilent(),
+		}
+		err := diff.NewExecutor(rep).Execute(ctx, opts)
+		if errors.Is(err, diff.ErrDiffFound) {
+			os.Exit(1)
+		}
 		return err
 	}
 
-	// Create options
-	opts := &diff.Options{
-		ConfigFile:  cfgFile,
-		ExitNonzero: diffExitNonzero,
-		Silent:      isSilent(),
+	targets, err := batch.LoadAll(configFiles)
+	if err != nil {
+		return fmt.Errorf("failed to load configurations: %w", err)
 	}
 
-	// Create reporter
-	reporter := cli.GetReporter(isSilent())
-
-	// Run diff
-	executor := diff.NewExecutor(reporter)
-	err = executor.Execute(ctx, opts)
-
-	// Handle exit-nonzero case
-	if errors.Is(err, diff.ErrDiffFound) {
-		os.Exit(1)
+	executor := diff.NewExecutor(rep)
+	// Per-target stdout payloads are collected in argument order so the
+	// combined stdout stays deterministic regardless of completion order
+	// (output.md §10.4). Indexed by target slot — distinct goroutines
+	// write to distinct slots so a sync.Mutex around the slice header
+	// is sufficient.
+	payloads := make([][]byte, len(targets))
+	hasChanges := make([]bool, len(targets))
+	indexByID := make(map[string]int, len(targets))
+	for i, t := range targets {
+		indexByID[t.Identifier] = i
 	}
+	var mu sync.Mutex
 
-	return err
+	o := &batch.Orchestrator{
+		Targets:         targets,
+		Parallel:        diffParallel,
+		ContinueOnError: diffContinueOnError,
+		Reporter:        rep,
+		Execute: func(ctx context.Context, t *batch.Target, tr reporter.TargetReporter) error {
+			payload, changed, runErr := executor.RunOnTarget(ctx, t, tr)
+			mu.Lock()
+			idx := indexByID[t.Identifier]
+			payloads[idx] = payload
+			hasChanges[idx] = changed
+			mu.Unlock()
+			return runErr
+		},
+	}
+	summary, runErr := o.Run(ctx)
+
+	flushDiffPayloads(rep, targets, payloads)
+
+	renderBatchSummary(rep, summary, len(targets), summaryConfig{noopVerb: "no-op"})
+
+	// --exit-nonzero collapses "any change" across all targets, matching
+	// the single-target contract (output.md §7.2 (e)). Even if some
+	// targets failed we still exit 1 — both conditions yield non-zero.
+	if diffExitNonzero {
+		for _, c := range hasChanges {
+			if c {
+				os.Exit(1)
+			}
+		}
+	}
+	return runErr
+}
+
+// flushDiffPayloads writes per-target diff bodies to stdout in argument
+// order with a `=== <id> ===` header per target (output.md §7.2 stdout
+// header rules — N>=2 always carries headers). Empty payloads (no-op
+// targets / failed targets) are skipped.
+func flushDiffPayloads(rep reporter.Reporter, targets []*batch.Target, payloads [][]byte) {
+	for i, t := range targets {
+		body := payloads[i]
+		if len(body) == 0 {
+			continue
+		}
+		rep.Diff([]byte(fmt.Sprintf("=== %s ===\n", t.Identifier)))
+		rep.Diff(body)
+		// Insert a blank line between adjacent target diffs so the
+		// stream stays readable when piped through `less`.
+		if i < len(targets)-1 {
+			rep.Diff([]byte("\n"))
+		}
+	}
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -37,9 +37,16 @@ and displays the differences in unified diff format.`,
 func runDiff(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
+	// TODO(multi-config PR-2 next phase): drop requireSingleConfig and route
+	// through batch.Orchestrator so `-c` may be repeated.
+	cfgFile, err := requireSingleConfig("diff")
+	if err != nil {
+		return err
+	}
+
 	// Create options
 	opts := &diff.Options{
-		ConfigFile:  configFile,
+		ConfigFile:  cfgFile,
 		ExitNonzero: diffExitNonzero,
 		Silent:      isSilent(),
 	}
@@ -49,7 +56,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 	// Run diff
 	executor := diff.NewExecutor(reporter)
-	err := executor.Execute(ctx, opts)
+	err = executor.Execute(ctx, opts)
 
 	// Handle exit-nonzero case
 	if errors.Is(err, diff.ErrDiffFound) {

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -110,7 +110,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 	flushDiffPayloads(rep, targets, payloads)
 
-	renderBatchSummary(rep, summary, len(targets), summaryConfig{noopVerb: "no-op"})
+	renderBatchSummary(summary, len(targets), summaryConfig{noopVerb: "no-op"})
 
 	// --exit-nonzero collapses "any change" across all targets, matching
 	// the single-target contract. Even if some targets failed we still

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -130,19 +130,21 @@ func runDiff(cmd *cobra.Command, args []string) error {
 // flushDiffPayloads writes per-target diff bodies to stdout in argument
 // order with a `=== <id> ===` header per target (output.md §7.2 stdout
 // header rules — N>=2 always carries headers). Empty payloads (no-op
-// targets / failed targets) are skipped.
+// targets / failed targets) are skipped. A blank line is inserted
+// before every non-first non-empty payload so the stream stays
+// readable when piped through `less`.
 func flushDiffPayloads(rep reporter.Reporter, targets []*batch.Target, payloads [][]byte) {
+	first := true
 	for i, t := range targets {
 		body := payloads[i]
 		if len(body) == 0 {
 			continue
 		}
-		rep.Diff([]byte(fmt.Sprintf("=== %s ===\n", t.Identifier)))
-		rep.Diff(body)
-		// Insert a blank line between adjacent target diffs so the
-		// stream stays readable when piped through `less`.
-		if i < len(targets)-1 {
+		if !first {
 			rep.Diff([]byte("\n"))
 		}
+		first = false
+		rep.Diff(fmt.Appendf(nil, "=== %s ===\n", t.Identifier))
+		rep.Diff(body)
 	}
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -34,11 +34,10 @@ func newDiffCmd() *cobra.Command {
 This command compares your local configuration file with the latest deployed version
 and displays the differences in unified diff format.
 
-Pass -c multiple times to diff several configurations in one invocation
-(see docs/design/multi-config.md). Multi-target diffs prefix each body
-with "=== <region>/<app>/<profile>/<env> ===" so the combined stream
-stays unambiguous; single-target output omits the header so it can be
-piped into patch/git apply.`,
+Pass -c multiple times to diff several configurations in one invocation.
+Multi-target diffs prefix each body with "=== <region>/<app>/<profile>/<env> ==="
+so the combined stream stays unambiguous; single-target output omits the
+header so it can be piped into patch/git apply.`,
 		RunE:         runDiff,
 		SilenceUsage: true, // Don't show usage on runtime errors
 	}
@@ -56,7 +55,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 	// Single-config keeps the existing path so the row identifier still
 	// shows the SDK-resolved default region when cfg.Region is empty
-	// (multi-config requires region in yml — multi-config.md §6.2).
+	// (multi-config requires region in yml).
 	if len(configFiles) <= 1 {
 		path := defaultConfigFile
 		if len(configFiles) == 1 {
@@ -81,10 +80,9 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 	executor := diff.NewExecutor(rep)
 	// Per-target stdout payloads are collected in argument order so the
-	// combined stdout stays deterministic regardless of completion order
-	// (output.md §10.4). Indexed by target slot — distinct goroutines
-	// write to distinct slots so a sync.Mutex around the slice header
-	// is sufficient.
+	// combined stdout stays deterministic regardless of completion order.
+	// Indexed by target slot — distinct goroutines write to distinct
+	// slots so a sync.Mutex around the slice header is sufficient.
 	payloads := make([][]byte, len(targets))
 	hasChanges := make([]bool, len(targets))
 	indexByID := make(map[string]int, len(targets))
@@ -115,8 +113,8 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	renderBatchSummary(rep, summary, len(targets), summaryConfig{noopVerb: "no-op"})
 
 	// --exit-nonzero collapses "any change" across all targets, matching
-	// the single-target contract (output.md §7.2 (e)). Even if some
-	// targets failed we still exit 1 — both conditions yield non-zero.
+	// the single-target contract. Even if some targets failed we still
+	// exit 1 — both conditions yield non-zero.
 	if diffExitNonzero {
 		for _, c := range hasChanges {
 			if c {
@@ -128,11 +126,10 @@ func runDiff(cmd *cobra.Command, args []string) error {
 }
 
 // flushDiffPayloads writes per-target diff bodies to stdout in argument
-// order with a `=== <id> ===` header per target (output.md §7.2 stdout
-// header rules — N>=2 always carries headers). Empty payloads (no-op
-// targets / failed targets) are skipped. A blank line is inserted
-// before every non-first non-empty payload so the stream stays
-// readable when piped through `less`.
+// order with a `=== <id> ===` header per target (N>=2 always carries
+// headers). Empty payloads (no-op targets / failed targets) are
+// skipped. A blank line is inserted before every non-first non-empty
+// payload so the stream stays readable when piped through `less`.
 func flushDiffPayloads(rep reporter.Reporter, targets []*batch.Target, payloads [][]byte) {
 	first := true
 	for i, t := range targets {

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -121,5 +124,77 @@ func TestDiffCommandExitNonzeroFlag(t *testing.T) {
 				t.Errorf("diffExitNonzero = %v, want %v", diffExitNonzero, tt.expectedFlag)
 			}
 		})
+	}
+}
+
+// TestRunDiff_MultiConfigLoadError exercises the multi-config branch in
+// runDiff: when one of the supplied -c paths fails to load, the
+// orchestrator never starts and the error wraps "failed to load
+// configurations".
+func TestRunDiff_MultiConfigLoadError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "diff-multi-load-*")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	good := filepath.Join(tmpDir, "good.yml")
+	if err := os.WriteFile(good, []byte("application: a\nconfiguration_profile: p\nenvironment: e\nregion: us-east-1\ndata_file: data.json\n"), 0o644); err != nil {
+		t.Fatalf("good: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("data: %v", err)
+	}
+	missing := filepath.Join(tmpDir, "missing.yml")
+
+	configFiles = []string{good, missing}
+	t.Cleanup(func() { configFiles = []string{defaultConfigFile} })
+
+	cmd := newDiffCmd()
+	err = runDiff(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to load configurations") {
+		t.Errorf("err = %q, want substring 'failed to load configurations'", err.Error())
+	}
+}
+
+// TestRunDiff_MultiConfigOrchestratorAWSError exercises the multi-config
+// branch in runDiff through to the orchestrator (covers payload buffer
+// setup, flushDiffPayloads, renderBatchSummary). AWS calls must fail
+// for this to work without credentials.
+func TestRunDiff_MultiConfigOrchestratorAWSError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "diff-multi-orch-*")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	makeConfig := func(name, env string) string {
+		path := filepath.Join(tmpDir, name)
+		body := "application: a\nconfiguration_profile: p\nregion: us-east-1\ndata_file: data.json\nenvironment: " + env + "\n"
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("config: %v", err)
+		}
+		return path
+	}
+	a := makeConfig("a.yml", "dev")
+	b := makeConfig("b.yml", "prod")
+	if err := os.WriteFile(filepath.Join(tmpDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("data: %v", err)
+	}
+
+	configFiles = []string{a, b}
+	silent = true
+	t.Cleanup(func() {
+		configFiles = []string{defaultConfigFile}
+		silent = false
+	})
+
+	cmd := newDiffCmd()
+	err = runDiff(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error from multi-config orchestrator path, got nil")
 	}
 }

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -68,7 +68,7 @@ func TestDiffCommandFlags(t *testing.T) {
 
 func TestRunDiffInvalidConfig(t *testing.T) {
 	// Reset flags
-	configFile = "nonexistent.yml"
+	configFiles = []string{"nonexistent.yml"}
 
 	err := runDiff(nil, nil)
 	if err == nil {
@@ -106,7 +106,7 @@ func TestDiffCommandExitNonzeroFlag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset flags
-			configFile = "apcdeploy.yml"
+			configFiles = []string{"apcdeploy.yml"}
 			diffExitNonzero = false
 
 			cmd := newDiffCmd()

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -37,9 +37,14 @@ Use --yes to skip the confirmation prompt (useful for scripts and automation).`,
 func runGet(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
+	cfgFile, err := requireSingleConfig("get")
+	if err != nil {
+		return err
+	}
+
 	// Create options
 	opts := &get.Options{
-		ConfigFile:       configFile,
+		ConfigFile:       cfgFile,
 		SkipConfirmation: getSkipConfirmation,
 	}
 

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -22,7 +22,7 @@ func TestGetCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset global flags for each test
-			configFile = "apcdeploy.yml"
+			configFiles = []string{"apcdeploy.yml"}
 
 			cmd := newGetCmd()
 			cmd.SetArgs(tt.args)
@@ -97,7 +97,7 @@ data_file: data.json
 			configPath := tt.setupFiles(t, tmpDir)
 
 			// Reset global flags
-			configFile = configPath
+			configFiles = []string{configPath}
 
 			// Create command
 			cmd := newGetCmd()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -49,13 +49,18 @@ to select from available resources.`,
 func runInit(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
+	cfgFile, err := requireSingleConfig("init")
+	if err != nil {
+		return err
+	}
+
 	// Create options
 	opts := &initPkg.Options{
 		Application: initApp,
 		Profile:     initProfile,
 		Environment: initEnv,
 		Region:      initRegion,
-		ConfigFile:  configFile,
+		ConfigFile:  cfgFile,
 		OutputData:  initOutputData,
 		Force:       initForce,
 		Silent:      isSilent(),

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -34,7 +34,7 @@ func TestInitCommand(t *testing.T) {
 			initProfile = ""
 			initEnv = ""
 			initRegion = ""
-			configFile = "apcdeploy.yml"
+			configFiles = []string{"apcdeploy.yml"}
 			initOutputData = ""
 			initForce = false
 
@@ -124,7 +124,7 @@ func TestRunInitWithAllFlags(t *testing.T) {
 			initProfile = tt.profile
 			initEnv = tt.env
 			initRegion = tt.region
-			configFile = tt.config
+			configFiles = []string{tt.config}
 			initOutputData = tt.outputData
 			initForce = tt.force
 

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -2,10 +2,17 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/cli"
 	"github.com/koh-sh/apcdeploy/internal/pull"
 	"github.com/spf13/cobra"
+)
+
+var (
+	pullParallel        int
+	pullContinueOnError bool
 )
 
 // PullCommand returns the pull command
@@ -23,33 +30,52 @@ This command retrieves the currently deployed configuration and overwrites your 
 Useful when configuration changes are made directly in the AWS Console and you want to sync
 your local files with the deployed state.
 
+Pass -c multiple times to pull several configurations in one invocation
+(see docs/design/multi-config.md for details).
+
 Note: This command does NOT use the AppConfig Data API, so it does not incur per-call charges.`,
 		RunE:         runPull,
 		SilenceUsage: true, // Don't show usage on runtime errors
 	}
+
+	cmd.Flags().IntVar(&pullParallel, "parallel", 0, "Maximum concurrent targets when -c is repeated (0 = all in parallel)")
+	cmd.Flags().BoolVar(&pullContinueOnError, "continue-on-error", false, "Run remaining targets after one fails (default: fail-fast)")
 
 	return cmd
 }
 
 func runPull(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
+	rep := cli.GetReporter(isSilent())
 
-	// TODO(multi-config PR-2 next phase): drop requireSingleConfig and route
-	// through batch.Orchestrator so `-c` may be repeated.
-	cfgFile, err := requireSingleConfig("pull")
+	// Single-config keeps the existing path so the row identifier still
+	// shows the SDK-resolved default region when cfg.Region is empty.
+	// Multi-config requires region in yml (multi-config.md §6.2) and
+	// flows through the orchestrator.
+	if len(configFiles) <= 1 {
+		path := defaultConfigFile
+		if len(configFiles) == 1 {
+			path = configFiles[0]
+		}
+		opts := &pull.Options{ConfigFile: path}
+		executor := pull.NewExecutor(rep)
+		return executor.Execute(ctx, opts)
+	}
+
+	targets, err := batch.LoadAll(configFiles)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load configurations: %w", err)
 	}
 
-	// Create options
-	opts := &pull.Options{
-		ConfigFile: cfgFile,
+	executor := pull.NewExecutor(rep)
+	o := &batch.Orchestrator{
+		Targets:         targets,
+		Parallel:        pullParallel,
+		ContinueOnError: pullContinueOnError,
+		Reporter:        rep,
+		Execute:         executor.RunOnTarget,
 	}
-
-	// Create reporter
-	reporter := cli.GetReporter(isSilent())
-
-	// Pull configuration
-	executor := pull.NewExecutor(reporter)
-	return executor.Execute(ctx, opts)
+	summary, runErr := o.Run(ctx)
+	renderBatchSummary(rep, summary, len(targets), summaryConfig{noopVerb: "no-op"})
+	return runErr
 }

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -34,9 +34,16 @@ Note: This command does NOT use the AppConfig Data API, so it does not incur per
 func runPull(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
+	// TODO(multi-config PR-2 next phase): drop requireSingleConfig and route
+	// through batch.Orchestrator so `-c` may be repeated.
+	cfgFile, err := requireSingleConfig("pull")
+	if err != nil {
+		return err
+	}
+
 	// Create options
 	opts := &pull.Options{
-		ConfigFile: configFile,
+		ConfigFile: cfgFile,
 	}
 
 	// Create reporter

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -75,6 +75,6 @@ func runPull(cmd *cobra.Command, args []string) error {
 		Execute:         executor.RunOnTarget,
 	}
 	summary, runErr := o.Run(ctx)
-	renderBatchSummary(rep, summary, len(targets), summaryConfig{noopVerb: "no-op"})
+	renderBatchSummary(summary, len(targets), summaryConfig{noopVerb: "no-op"})
 	return runErr
 }

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -30,8 +30,7 @@ This command retrieves the currently deployed configuration and overwrites your 
 Useful when configuration changes are made directly in the AWS Console and you want to sync
 your local files with the deployed state.
 
-Pass -c multiple times to pull several configurations in one invocation
-(see docs/design/multi-config.md for details).
+Pass -c multiple times to pull several configurations in one invocation.
 
 Note: This command does NOT use the AppConfig Data API, so it does not incur per-call charges.`,
 		RunE:         runPull,
@@ -50,8 +49,8 @@ func runPull(cmd *cobra.Command, args []string) error {
 
 	// Single-config keeps the existing path so the row identifier still
 	// shows the SDK-resolved default region when cfg.Region is empty.
-	// Multi-config requires region in yml (multi-config.md §6.2) and
-	// flows through the orchestrator.
+	// Multi-config requires region in yml and flows through the
+	// orchestrator.
 	if len(configFiles) <= 1 {
 		path := defaultConfigFile
 		if len(configFiles) == 1 {

--- a/cmd/pull_test.go
+++ b/cmd/pull_test.go
@@ -114,7 +114,7 @@ data_file: data.json
 			configPath := tt.setupFiles(t, tmpDir)
 
 			// Reset global flags
-			configFile = configPath
+			configFiles = []string{configPath}
 
 			// Create command
 			cmd := newPullCmd()

--- a/cmd/pull_test.go
+++ b/cmd/pull_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -126,6 +127,86 @@ data_file: data.json
 				t.Errorf("runPull() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestRunPull_MultiConfigOrchestratorAWSError exercises the multi-config
+// branch in runPull through to the orchestrator, expecting AWS to fail
+// (no credentials in the test environment). This covers the branch
+// from LoadAll success → orchestrator setup → renderBatchSummary, which
+// the load-error test exits before reaching.
+func TestRunPull_MultiConfigOrchestratorAWSError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pull-multi-orch-*")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	makeConfig := func(name, env string) string {
+		path := filepath.Join(tmpDir, name)
+		body := "application: a\nconfiguration_profile: p\nregion: us-east-1\ndata_file: data.json\nenvironment: " + env + "\n"
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("config: %v", err)
+		}
+		return path
+	}
+	a := makeConfig("a.yml", "dev")
+	b := makeConfig("b.yml", "prod")
+	if err := os.WriteFile(filepath.Join(tmpDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("data: %v", err)
+	}
+
+	configFiles = []string{a, b}
+	silent = true // suppress orchestrator output during test
+	t.Cleanup(func() {
+		configFiles = []string{defaultConfigFile}
+		silent = false
+	})
+
+	cmd := newPullCmd()
+	err = runPull(cmd, nil)
+	// AWS call (or credentials lookup) must fail because we have no
+	// real backing. Either an aggregate "N target(s) failed" from the
+	// orchestrator or any non-nil error is acceptable — the goal is to
+	// exercise the multi-config branch.
+	if err == nil {
+		t.Fatal("expected error from multi-config orchestrator path, got nil")
+	}
+}
+
+// TestRunPull_MultiConfigLoadError exercises the multi-config branch in
+// runPull: when one of the supplied -c paths fails to load, the
+// orchestrator never starts and the error is wrapped with
+// "failed to load configurations".
+func TestRunPull_MultiConfigLoadError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "pull-multi-load-*")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	good := filepath.Join(tmpDir, "good.yml")
+	if err := os.WriteFile(good, []byte("application: a\nconfiguration_profile: p\nenvironment: e\nregion: us-east-1\ndata_file: data.json\n"), 0o644); err != nil {
+		t.Fatalf("good: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("data: %v", err)
+	}
+	missing := filepath.Join(tmpDir, "missing.yml")
+
+	configFiles = []string{good, missing}
+	t.Cleanup(func() { configFiles = []string{defaultConfigFile} })
+
+	cmd := newPullCmd()
+	err = runPull(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to load configurations") {
+		t.Errorf("err = %q, want substring 'failed to load configurations'", err.Error())
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("err = %q, want substring %q", err.Error(), missing)
 	}
 }
 

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -36,9 +36,14 @@ It automatically finds the current ongoing deployment and stops it.`,
 func runRollback(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
+	cfgFile, err := requireSingleConfig("rollback")
+	if err != nil {
+		return err
+	}
+
 	// Create options
 	opts := &rollback.Options{
-		ConfigFile:       configFile,
+		ConfigFile:       cfgFile,
 		Silent:           isSilent(),
 		SkipConfirmation: rollbackSkipConfirmation,
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ var (
 	date    string
 
 	// Global flags. configFiles is a slice so the run/diff/pull commands can
-	// accept `-c` repeatedly (multi-config.md F-01). Single-config commands
+	// accept `-c` repeatedly. Single-config commands
 	// (init/get/status/rollback/edit) call requireSingleConfig() to enforce
 	// `len == 1` themselves.
 	configFiles []string
@@ -88,7 +88,7 @@ func Execute() {
 		rep := cli.GetReporter(silent)
 		rep.Error(err.Error())
 		// Append a Resolution: <hint> line when the underlying AWS error code
-		// has a documented remediation (output.md §8.3 / internal/errors).
+		// has a documented remediation.
 		// Emitted via Warn (⚠) instead of Error (✗) so the visual hierarchy is
 		// "what failed" first, "how to recover" second; both lines reach
 		// stderr even under --silent because Warn-via-the-real-reporter is
@@ -114,8 +114,7 @@ func isSilent() bool {
 // requireSingleConfig enforces that single-config commands receive exactly
 // one `-c` value. It returns the single path when valid; otherwise it
 // returns an error explaining that the command does not support
-// multi-config (per docs/design/multi-config.md §3 non-goals — only
-// run/diff/pull do).
+// multi-config (only run/diff/pull do).
 func requireSingleConfig(cmdName string) (string, error) {
 	switch len(configFiles) {
 	case 0:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,10 +24,17 @@ var (
 	commit  string
 	date    string
 
-	// Global flags
-	configFile string
-	silent     bool
+	// Global flags. configFiles is a slice so the run/diff/pull commands can
+	// accept `-c` repeatedly (multi-config.md F-01). Single-config commands
+	// (init/get/status/rollback/edit) call requireSingleConfig() to enforce
+	// `len == 1` themselves.
+	configFiles []string
+	silent      bool
 )
+
+// defaultConfigFile is the implicit -c value when the user passes no
+// `-c` flag. Kept as a constant so tests and the flag default agree.
+const defaultConfigFile = "apcdeploy.yml"
 
 // NewRootCommand creates and returns the root command
 func NewRootCommand() *cobra.Command {
@@ -39,8 +46,10 @@ It provides commands to initialize, deploy, diff, and check the status of config
 		Version: fmt.Sprintf("%s (Built on %s from Git SHA %s)", version, date, commit),
 	}
 
-	// Global flags
-	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "apcdeploy.yml", "config file path")
+	// Global flags. `-c` is a string slice so run/diff/pull can accept it
+	// multiple times for multi-config; single-config commands validate
+	// the count via requireSingleConfig().
+	rootCmd.PersistentFlags().StringSliceVarP(&configFiles, "config", "c", []string{defaultConfigFile}, "config file path (run/diff/pull may pass -c multiple times)")
 	rootCmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "suppress verbose output, show only essential information")
 
 	// Add subcommands
@@ -100,6 +109,24 @@ func Execute() {
 // isSilent returns whether silent mode is enabled
 func isSilent() bool {
 	return silent
+}
+
+// requireSingleConfig enforces that single-config commands receive exactly
+// one `-c` value. It returns the single path when valid; otherwise it
+// returns an error explaining that the command does not support
+// multi-config (per docs/design/multi-config.md §3 non-goals — only
+// run/diff/pull do).
+func requireSingleConfig(cmdName string) (string, error) {
+	switch len(configFiles) {
+	case 0:
+		// Cobra's default keeps the slice non-empty, but be defensive in
+		// case a test or pre-run hook clears it.
+		return defaultConfigFile, nil
+	case 1:
+		return configFiles[0], nil
+	default:
+		return "", fmt.Errorf("%s does not support multiple -c flags (got %d)", cmdName, len(configFiles))
+	}
 }
 
 // maxDescriptionLength matches the AppConfig API limit on the Description

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -130,6 +130,6 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 	summary, runErr := o.Run(ctx)
 	withElapsed := runWaitDeploy || runWaitBake
-	renderBatchSummary(rep, summary, len(targets), summaryConfig{noopVerb: "no-op", withElapsed: withElapsed})
+	renderBatchSummary(summary, len(targets), summaryConfig{noopVerb: "no-op", withElapsed: withElapsed})
 	return runErr
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/cli"
+	"github.com/koh-sh/apcdeploy/internal/reporter"
 	"github.com/koh-sh/apcdeploy/internal/run"
 	"github.com/spf13/cobra"
 )
@@ -15,15 +17,20 @@ const (
 	// AppConfig.Canary10Percent20Minutes (20 min deploy + 10 min bake) under
 	// --wait-bake. Strategies with longer total durations (e.g.
 	// AppConfig.Linear20PercentEvery6Minutes) require an explicit --timeout.
+	//
+	// In the multi-config path the same value applies INDEPENDENTLY to each
+	// target (multi-config.md §7.4) — it is not a global wall-clock cap.
 	DefaultDeploymentTimeout = 1800
 )
 
 var (
-	runWaitDeploy  bool
-	runWaitBake    bool
-	runTimeout     int
-	runForce       bool
-	runDescription string
+	runWaitDeploy      bool
+	runWaitBake        bool
+	runTimeout         int
+	runForce           bool
+	runDescription     string
+	runParallel        int
+	runContinueOnError bool
 )
 
 // RunCommand returns the run command
@@ -42,16 +49,22 @@ This command will:
 2. Validate the configuration data
 3. Create a new hosted configuration version
 4. Start a deployment to the specified environment
-5. Optionally wait for the deployment phase (--wait-deploy) or full completion (--wait-bake)`,
+5. Optionally wait for the deployment phase (--wait-deploy) or full completion (--wait-bake)
+
+Pass -c multiple times to run several deployments in one invocation
+(see docs/design/multi-config.md). Multi-target runs honour --parallel
+and --continue-on-error; --timeout is per-target, not global.`,
 		RunE:         runRun,
 		SilenceUsage: true, // Don't show usage on runtime errors
 	}
 
 	cmd.Flags().BoolVar(&runWaitDeploy, "wait-deploy", false, "Wait for deployment phase to complete (until baking starts)")
 	cmd.Flags().BoolVar(&runWaitBake, "wait-bake", false, "Wait for complete deployment including baking phase")
-	cmd.Flags().IntVar(&runTimeout, "timeout", DefaultDeploymentTimeout, "Timeout in seconds for deployment")
+	cmd.Flags().IntVar(&runTimeout, "timeout", DefaultDeploymentTimeout, "Per-target timeout in seconds for deployment")
 	cmd.Flags().BoolVar(&runForce, "force", false, "Force deployment even when there are no changes")
 	cmd.Flags().StringVar(&runDescription, "description", "", fmt.Sprintf(`Description attached to the configuration version and deployment (max %d chars; defaults to %q, pass "" to clear)`, maxDescriptionLength, defaultDescription))
+	cmd.Flags().IntVar(&runParallel, "parallel", 0, "Maximum concurrent targets when -c is repeated (0 = all in parallel)")
+	cmd.Flags().BoolVar(&runContinueOnError, "continue-on-error", false, "Run remaining targets after one fails (default: fail-fast)")
 
 	return cmd
 }
@@ -64,16 +77,35 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 	description := resolveDescription(cmd, runDescription)
 
-	// TODO(multi-config PR-2 next phase): drop requireSingleConfig and route
-	// through batch.Orchestrator so `-c` may be repeated. For now keep
-	// single-config behaviour while the cmd-flag refactor lands.
-	cfgFile, err := requireSingleConfig("run")
-	if err != nil {
-		return err
+	rep := cli.GetReporter(isSilent())
+
+	// Single-config keeps the existing path so the row identifier still
+	// shows the SDK-resolved default region when cfg.Region is empty
+	// (multi-config requires region in yml — multi-config.md §6.2).
+	if len(configFiles) <= 1 {
+		path := defaultConfigFile
+		if len(configFiles) == 1 {
+			path = configFiles[0]
+		}
+		opts := &run.Options{
+			ConfigFile:  path,
+			WaitDeploy:  runWaitDeploy,
+			WaitBake:    runWaitBake,
+			Timeout:     runTimeout,
+			Force:       runForce,
+			Description: description,
+		}
+		executor := run.NewExecutor(rep)
+		return executor.Execute(ctx, opts)
 	}
 
-	opts := &run.Options{
-		ConfigFile:  cfgFile,
+	targets, err := batch.LoadAll(configFiles)
+	if err != nil {
+		return fmt.Errorf("failed to load configurations: %w", err)
+	}
+
+	executor := run.NewExecutor(rep)
+	baseOpts := &run.Options{
 		WaitDeploy:  runWaitDeploy,
 		WaitBake:    runWaitBake,
 		Timeout:     runTimeout,
@@ -81,8 +113,23 @@ func runRun(cmd *cobra.Command, args []string) error {
 		Description: description,
 	}
 
-	reporter := cli.GetReporter(isSilent())
-
-	executor := run.NewExecutor(reporter)
-	return executor.Execute(ctx, opts)
+	o := &batch.Orchestrator{
+		Targets:         targets,
+		Parallel:        runParallel,
+		ContinueOnError: runContinueOnError,
+		Reporter:        rep,
+		Execute: func(ctx context.Context, t *batch.Target, tr reporter.TargetReporter) error {
+			// Each call gets its own Options copy via the per-target
+			// ConfigFile (kept for parity with single-config — the
+			// executor reads it for diagnostics but the data file path
+			// already lives in t.Config.DataFile).
+			perTarget := *baseOpts
+			perTarget.ConfigFile = t.Path
+			return executor.RunOnTarget(ctx, t, tr, &perTarget)
+		},
+	}
+	summary, runErr := o.Run(ctx)
+	withElapsed := runWaitDeploy || runWaitBake
+	renderBatchSummary(rep, summary, len(targets), summaryConfig{noopVerb: "no-op", withElapsed: withElapsed})
+	return runErr
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,7 +19,7 @@ const (
 	// AppConfig.Linear20PercentEvery6Minutes) require an explicit --timeout.
 	//
 	// In the multi-config path the same value applies INDEPENDENTLY to each
-	// target (multi-config.md §7.4) — it is not a global wall-clock cap.
+	// target — it is not a global wall-clock cap.
 	DefaultDeploymentTimeout = 1800
 )
 
@@ -51,9 +51,9 @@ This command will:
 4. Start a deployment to the specified environment
 5. Optionally wait for the deployment phase (--wait-deploy) or full completion (--wait-bake)
 
-Pass -c multiple times to run several deployments in one invocation
-(see docs/design/multi-config.md). Multi-target runs honour --parallel
-and --continue-on-error; --timeout is per-target, not global.`,
+Pass -c multiple times to run several deployments in one invocation.
+Multi-target runs honour --parallel and --continue-on-error; --timeout
+is per-target, not global.`,
 		RunE:         runRun,
 		SilenceUsage: true, // Don't show usage on runtime errors
 	}
@@ -81,7 +81,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 
 	// Single-config keeps the existing path so the row identifier still
 	// shows the SDK-resolved default region when cfg.Region is empty
-	// (multi-config requires region in yml — multi-config.md §6.2).
+	// (multi-config requires region in yml).
 	if len(configFiles) <= 1 {
 		path := defaultConfigFile
 		if len(configFiles) == 1 {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -64,8 +64,16 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 	description := resolveDescription(cmd, runDescription)
 
+	// TODO(multi-config PR-2 next phase): drop requireSingleConfig and route
+	// through batch.Orchestrator so `-c` may be repeated. For now keep
+	// single-config behaviour while the cmd-flag refactor lands.
+	cfgFile, err := requireSingleConfig("run")
+	if err != nil {
+		return err
+	}
+
 	opts := &run.Options{
-		ConfigFile:  configFile,
+		ConfigFile:  cfgFile,
 		WaitDeploy:  runWaitDeploy,
 		WaitBake:    runWaitBake,
 		Timeout:     runTimeout,

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -37,7 +37,7 @@ func TestRunCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset global flags for each test. We touch every flag-bound
 			// global so `go test -shuffle=on` can't expose ordering bugs.
-			configFile = "apcdeploy.yml"
+			configFiles = []string{"apcdeploy.yml"}
 			runWaitDeploy = false
 			runWaitBake = false
 			runTimeout = DefaultDeploymentTimeout
@@ -56,7 +56,7 @@ func TestRunCommand(t *testing.T) {
 }
 
 func TestRunCommandFlags(t *testing.T) {
-	configFile = "apcdeploy.yml"
+	configFiles = []string{"apcdeploy.yml"}
 	runWaitDeploy = false
 	runWaitBake = false
 	runTimeout = DefaultDeploymentTimeout
@@ -93,7 +93,7 @@ func TestRunCommandFlags(t *testing.T) {
 }
 
 func TestRunCommandWaitFlags(t *testing.T) {
-	configFile = "apcdeploy.yml"
+	configFiles = []string{"apcdeploy.yml"}
 	runWaitDeploy = false
 	runWaitBake = false
 	runTimeout = DefaultDeploymentTimeout

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -236,5 +238,76 @@ func TestValidateDescription(t *testing.T) {
 				t.Errorf("validateDescription(runes=%d) error = %v, wantErr %v", len([]rune(tt.input)), err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestRunRun_MultiConfigLoadError exercises the multi-config branch in
+// runRun: when one of the supplied -c paths fails to load, the
+// orchestrator never starts and the error wraps "failed to load
+// configurations".
+func TestRunRun_MultiConfigLoadError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "run-multi-load-*")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	good := filepath.Join(tmpDir, "good.yml")
+	if err := os.WriteFile(good, []byte("application: a\nconfiguration_profile: p\nenvironment: e\nregion: us-east-1\ndata_file: data.json\n"), 0o644); err != nil {
+		t.Fatalf("good: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("data: %v", err)
+	}
+	missing := filepath.Join(tmpDir, "missing.yml")
+
+	configFiles = []string{good, missing}
+	t.Cleanup(func() { configFiles = []string{defaultConfigFile} })
+
+	cmd := newRunCmd()
+	err = runRun(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to load configurations") {
+		t.Errorf("err = %q, want substring 'failed to load configurations'", err.Error())
+	}
+}
+
+// TestRunRun_MultiConfigOrchestratorAWSError exercises the multi-config
+// branch in runRun through to the orchestrator setup + summary render.
+// AWS calls must fail for this to work without credentials.
+func TestRunRun_MultiConfigOrchestratorAWSError(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "run-multi-orch-*")
+	if err != nil {
+		t.Fatalf("temp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	makeConfig := func(name, env string) string {
+		path := filepath.Join(tmpDir, name)
+		body := "application: a\nconfiguration_profile: p\nregion: us-east-1\ndata_file: data.json\nenvironment: " + env + "\n"
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("config: %v", err)
+		}
+		return path
+	}
+	a := makeConfig("a.yml", "dev")
+	b := makeConfig("b.yml", "prod")
+	if err := os.WriteFile(filepath.Join(tmpDir, "data.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("data: %v", err)
+	}
+
+	configFiles = []string{a, b}
+	silent = true
+	t.Cleanup(func() {
+		configFiles = []string{defaultConfigFile}
+		silent = false
+	})
+
+	cmd := newRunCmd()
+	err = runRun(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error from multi-config orchestrator path, got nil")
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -35,9 +35,14 @@ identified by deployment number.`,
 func runStatus(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
+	cfgFile, err := requireSingleConfig("status")
+	if err != nil {
+		return err
+	}
+
 	// Create options
 	opts := &status.Options{
-		ConfigFile:   configFile,
+		ConfigFile:   cfgFile,
 		DeploymentID: statusDeploymentID,
 		Silent:       isSilent(),
 	}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -27,7 +27,7 @@ func TestStatusCommand(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Reset global flags for each test
-			configFile = "apcdeploy.yml"
+			configFiles = []string{"apcdeploy.yml"}
 			statusDeploymentID = ""
 
 			cmd := newStatusCmd()
@@ -102,7 +102,7 @@ deployment_strategy: test-strategy
 			configPath := tt.setupFiles(t, tmpDir)
 
 			// Reset global flags
-			configFile = configPath
+			configFiles = []string{configPath}
 			statusDeploymentID = ""
 
 			// Create command
@@ -139,7 +139,7 @@ func TestStatusCommandStructure(t *testing.T) {
 }
 
 func TestStatusCommandFlags(t *testing.T) {
-	configFile = "apcdeploy.yml"
+	configFiles = []string{"apcdeploy.yml"}
 	statusDeploymentID = ""
 
 	cmd := newStatusCmd()

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -81,7 +81,7 @@ sed -i '' 's/data.json/data.txt/' apcdeploy.yml
 echo "text" > data.txt
 $APCDEPLOY run --wait-bake --silent
 
-echo "Multi-config: -c repeated for run/diff/pull (multi-config.md)"
+echo "Multi-config: -c repeated for run/diff/pull"
 title "========== S3: Multi-config =========="
 # Placed right after S2 so the json-freeform/dev + json-freeform/staging
 # pair is exercised before any later section perturbs their AWS state
@@ -115,7 +115,7 @@ $APCDEPLOY get --silent --yes -c "$MC_DIR/stg/apcdeploy.yml" | jq -e '.mc == "st
 $APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>&1 | grep -qE "no changes"
 
 # Modify only the dev target's data; the multi-target diff stdout must
-# contain the `=== <id> ===` header for dev only (output.md §7.2).
+# contain the `=== <id> ===` header for dev only.
 echo '{"mc":"dev-2"}' > "$MC_DIR/dev/data.json"
 diff_out=$($APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>/dev/null || true)
 echo "$diff_out" | grep -q "=== ${REGION}/${APP}/json-freeform/dev ==="

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -213,5 +213,70 @@ rc=0; EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"e":"x"}' $APCDEPLOY edit --r
 echo '{"e":"1"}' > data.json
 if $APCDEPLOY run --wait-bake --timeout -1 --silent; then exit 1; fi
 
-rm data.txt data.yaml data.json apcdeploy.yml apcdeploy
+# Reset working state before multi-config: the previous sections leave
+# whatever apcdeploy.yml the last init produced; the multi-config block
+# below builds its own fixtures from scratch.
+rm -f data.txt data.yaml data.json apcdeploy.yml
+
+echo "Multi-config: -c repeated for run/diff/pull (multi-config.md)"
+title "========== S9: Multi-config =========="
+MC_DIR=multi-config
+rm -rf "$MC_DIR"
+mkdir -p "$MC_DIR/dev" "$MC_DIR/stg"
+
+# Build two independent fixtures via init, one per environment so each
+# resolves to a distinct (region/app/profile/env) identifier.
+( cd "$MC_DIR/dev" && ../../apcdeploy init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force )
+sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" "$MC_DIR/dev/apcdeploy.yml"
+echo '{"mc":"dev-1"}' > "$MC_DIR/dev/data.json"
+
+( cd "$MC_DIR/stg" && ../../apcdeploy init --silent --app "$APP" --profile json-freeform --env staging --region "$REGION" --force )
+sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" "$MC_DIR/stg/apcdeploy.yml"
+echo '{"mc":"stg-1"}' > "$MC_DIR/stg/data.json"
+
+# Multi-config run deploys both targets; --wait-bake ensures we exit
+# only after both have COMPLETE.
+$APCDEPLOY run -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --wait-bake --silent
+$APCDEPLOY get --silent --yes -c "$MC_DIR/dev/apcdeploy.yml" | jq -e '.mc == "dev-1"' > /dev/null
+$APCDEPLOY get --silent --yes -c "$MC_DIR/stg/apcdeploy.yml" | jq -e '.mc == "stg-1"' > /dev/null
+
+# Multi-config diff: no changes for either target.
+$APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>&1 | grep -qE "no changes"
+
+# Modify one target's data; multi-config diff stdout must include the
+# `=== <id> ===` header for the changed target only.
+echo '{"mc":"dev-2"}' > "$MC_DIR/dev/data.json"
+diff_out=$($APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>/dev/null || true)
+echo "$diff_out" | grep -q "=== ${REGION}/${APP}/json-freeform/dev ==="
+if echo "$diff_out" | grep -q "=== ${REGION}/${APP}/json-freeform/staging ==="; then
+    echo "ERROR: staging had no changes — its === header should not appear"
+    exit 1
+fi
+
+# Multi-config pull: rewriting the changed local file restores the
+# deployed content, then both files report no changes.
+$APCDEPLOY pull -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --silent
+jq -e '.mc == "dev-1"' "$MC_DIR/dev/data.json" > /dev/null
+jq -e '.mc == "stg-1"' "$MC_DIR/stg/data.json" > /dev/null
+
+# Duplicate-target detection: pointing the same -c twice must be
+# silently deduplicated; pointing two configs at the same identifier
+# (different paths) must error.
+$APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/dev/apcdeploy.yml" --silent
+mkdir -p "$MC_DIR/dup"
+cp "$MC_DIR/dev/apcdeploy.yml" "$MC_DIR/dup/apcdeploy.yml"
+cp "$MC_DIR/dev/data.json" "$MC_DIR/dup/data.json"
+if $APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/dup/apcdeploy.yml" --silent; then
+    echo "ERROR: duplicate target should have failed"
+    exit 1
+fi
+
+# Single-config commands reject multi -c with a clear error.
+if $APCDEPLOY status -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --silent 2>/dev/null; then
+    echo "ERROR: status must reject multi -c"
+    exit 1
+fi
+
+rm -rf "$MC_DIR"
+rm -f apcdeploy
 echo "✅ All tests passed"

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -13,7 +13,7 @@ WORKDIR="./e2e/"
 use_strategy() { sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" apcdeploy.yml; }
 use_slow_strategy() { sed -i '' "s/deployment_strategy:.*/deployment_strategy: E2E-Slow-Strategy/" apcdeploy.yml; }
 
-# Fake editor used by S7/E3/E5. Reads content from $APCDEPLOY_EDIT_CONTENT
+# Fake editor used by S8/E3/E5. Reads content from $APCDEPLOY_EDIT_CONTENT
 # rather than embedding it, so callers can vary the bytes safely without
 # re-writing the fixture or worrying about shell-quote escaping.
 FAKE_EDITOR=./edit-fixture.sh
@@ -81,8 +81,77 @@ sed -i '' 's/data.json/data.txt/' apcdeploy.yml
 echo "text" > data.txt
 $APCDEPLOY run --wait-bake --silent
 
+echo "Multi-config: -c repeated for run/diff/pull (multi-config.md)"
+title "========== S3: Multi-config =========="
+# Placed right after S2 so the json-freeform/dev + json-freeform/staging
+# pair is exercised before any later section perturbs their AWS state
+# (S7 rollback, E3 in-flight slow deploys, etc.). Build self-contained
+# fixtures under ./multi-config/{dev,stg}/ so the trailing rm in the
+# success path covers them via `rm -rf` below.
+MC_DIR=multi-config
+rm -rf "$MC_DIR"
+mkdir -p "$MC_DIR/dev" "$MC_DIR/stg"
+
+# init populates apcdeploy.yml + (if a prior deployment exists) data.json.
+# We then overwrite the strategy and data so each target deploys fresh
+# content via S3's run; staging starts with no prior deployment on the
+# very first e2e run, in which case init creates only the yml.
+( cd "$MC_DIR/dev" && ../../apcdeploy init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force )
+sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" "$MC_DIR/dev/apcdeploy.yml"
+echo '{"mc":"dev-1"}' > "$MC_DIR/dev/data.json"
+
+( cd "$MC_DIR/stg" && ../../apcdeploy init --silent --app "$APP" --profile json-freeform --env staging --region "$REGION" --force )
+sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" "$MC_DIR/stg/apcdeploy.yml"
+echo '{"mc":"stg-1"}' > "$MC_DIR/stg/data.json"
+
+# Multi-config run deploys both targets in parallel; --wait-bake makes
+# the orchestrator wait until both reach COMPLETE before returning.
+$APCDEPLOY run -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --wait-bake --silent
+$APCDEPLOY get --silent --yes -c "$MC_DIR/dev/apcdeploy.yml" | jq -e '.mc == "dev-1"' > /dev/null
+$APCDEPLOY get --silent --yes -c "$MC_DIR/stg/apcdeploy.yml" | jq -e '.mc == "stg-1"' > /dev/null
+
+# Multi-config diff: both targets report no changes against the deploy
+# we just made. Without --silent the per-target rows show on stderr.
+$APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>&1 | grep -qE "no changes"
+
+# Modify only the dev target's data; the multi-target diff stdout must
+# contain the `=== <id> ===` header for dev only (output.md §7.2).
+echo '{"mc":"dev-2"}' > "$MC_DIR/dev/data.json"
+diff_out=$($APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>/dev/null || true)
+echo "$diff_out" | grep -q "=== ${REGION}/${APP}/json-freeform/dev ==="
+if echo "$diff_out" | grep -q "=== ${REGION}/${APP}/json-freeform/staging ==="; then
+    echo "ERROR: staging had no changes — its === header should not appear"
+    exit 1
+fi
+
+# Multi-config pull: rewriting the changed local file restores the
+# deployed content, then both files report no changes.
+$APCDEPLOY pull -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --silent
+jq -e '.mc == "dev-1"' "$MC_DIR/dev/data.json" > /dev/null
+jq -e '.mc == "stg-1"' "$MC_DIR/stg/data.json" > /dev/null
+
+# Path-level dedup: the same -c twice must be silently collapsed.
+$APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/dev/apcdeploy.yml" --silent
+# Identifier-level dedup: two distinct paths pointing at the same
+# region/app/profile/env 4-tuple must error before any AWS work.
+mkdir -p "$MC_DIR/dup"
+cp "$MC_DIR/dev/apcdeploy.yml" "$MC_DIR/dup/apcdeploy.yml"
+cp "$MC_DIR/dev/data.json" "$MC_DIR/dup/data.json"
+if $APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/dup/apcdeploy.yml" --silent; then
+    echo "ERROR: duplicate identifier should have failed"
+    exit 1
+fi
+
+# Single-config commands reject multi -c with a clear error.
+if $APCDEPLOY status -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --silent 2>/dev/null; then
+    echo "ERROR: status must reject multi -c"
+    exit 1
+fi
+
+rm -rf "$MC_DIR"
+
 echo "Deployment control: skip unchanged, force deploy, async run"
-title "========== S3: Deployment Control =========="
+title "========== S4: Deployment Control =========="
 $APCDEPLOY init --silent --app "$APP" --profile json-freeform --env staging --region "$REGION" --force
 use_strategy
 echo '{"t":"1"}' > data.json
@@ -93,7 +162,7 @@ echo '{"t":"2"}' > data.json
 $APCDEPLOY run --silent
 
 echo "Config file generation and deployment strategy verification"
-title "========== S4: Config =========="
+title "========== S5: Config =========="
 $APCDEPLOY init --silent --app "$APP" --profile yaml-config --env dev --region "$REGION" --force
 grep -q "region: $REGION" apcdeploy.yml
 use_strategy
@@ -103,7 +172,7 @@ $APCDEPLOY run --wait-bake --silent
 $APCDEPLOY status --silent | grep -q "COMPLETE"
 
 echo "CI mode: diff --exit-nonzero for detecting changes"
-title "========== S5: CI =========="
+title "========== S6: CI =========="
 $APCDEPLOY init --silent --app "$APP" --profile text-config --env dev --region "$REGION" --force
 use_strategy
 sed -i '' 's/data.json/data.txt/' apcdeploy.yml
@@ -114,7 +183,7 @@ $APCDEPLOY run --wait-bake --timeout 300 --silent
 $APCDEPLOY diff --silent --exit-nonzero
 
 echo "Rollback: stop ongoing deployment with slow strategy"
-title "========== S6: Rollback =========="
+title "========== S7: Rollback =========="
 $APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
 use_slow_strategy
 echo '{"r":"1"}' > data.json
@@ -124,7 +193,7 @@ $APCDEPLOY status --silent | grep -q "ROLLED_BACK"
 if $APCDEPLOY rollback --silent --yes; then exit 1; fi
 
 echo "Edit: $EDITOR-driven workflow (happy, no-op, invalid)"
-title "========== S7: Edit =========="
+title "========== S8: Edit =========="
 $APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
 use_strategy
 echo '{"e":"seed"}' > data.json
@@ -136,7 +205,7 @@ EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"e":"new"}' $APCDEPLOY edit --regio
 if EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='not-json' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile json-freeform --env dev --silent; then exit 1; fi
 
 echo "Description: default marker, explicit value, opt-out, length cap, edit"
-title "========== S8: Description =========="
+title "========== S9: Description =========="
 $APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
 use_strategy
 echo '{"d":"1"}' > data.json
@@ -213,70 +282,5 @@ rc=0; EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"e":"x"}' $APCDEPLOY edit --r
 echo '{"e":"1"}' > data.json
 if $APCDEPLOY run --wait-bake --timeout -1 --silent; then exit 1; fi
 
-# Reset working state before multi-config: the previous sections leave
-# whatever apcdeploy.yml the last init produced; the multi-config block
-# below builds its own fixtures from scratch.
-rm -f data.txt data.yaml data.json apcdeploy.yml
-
-echo "Multi-config: -c repeated for run/diff/pull (multi-config.md)"
-title "========== S9: Multi-config =========="
-MC_DIR=multi-config
-rm -rf "$MC_DIR"
-mkdir -p "$MC_DIR/dev" "$MC_DIR/stg"
-
-# Build two independent fixtures via init, one per environment so each
-# resolves to a distinct (region/app/profile/env) identifier.
-( cd "$MC_DIR/dev" && ../../apcdeploy init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force )
-sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" "$MC_DIR/dev/apcdeploy.yml"
-echo '{"mc":"dev-1"}' > "$MC_DIR/dev/data.json"
-
-( cd "$MC_DIR/stg" && ../../apcdeploy init --silent --app "$APP" --profile json-freeform --env staging --region "$REGION" --force )
-sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" "$MC_DIR/stg/apcdeploy.yml"
-echo '{"mc":"stg-1"}' > "$MC_DIR/stg/data.json"
-
-# Multi-config run deploys both targets; --wait-bake ensures we exit
-# only after both have COMPLETE.
-$APCDEPLOY run -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --wait-bake --silent
-$APCDEPLOY get --silent --yes -c "$MC_DIR/dev/apcdeploy.yml" | jq -e '.mc == "dev-1"' > /dev/null
-$APCDEPLOY get --silent --yes -c "$MC_DIR/stg/apcdeploy.yml" | jq -e '.mc == "stg-1"' > /dev/null
-
-# Multi-config diff: no changes for either target.
-$APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>&1 | grep -qE "no changes"
-
-# Modify one target's data; multi-config diff stdout must include the
-# `=== <id> ===` header for the changed target only.
-echo '{"mc":"dev-2"}' > "$MC_DIR/dev/data.json"
-diff_out=$($APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>/dev/null || true)
-echo "$diff_out" | grep -q "=== ${REGION}/${APP}/json-freeform/dev ==="
-if echo "$diff_out" | grep -q "=== ${REGION}/${APP}/json-freeform/staging ==="; then
-    echo "ERROR: staging had no changes — its === header should not appear"
-    exit 1
-fi
-
-# Multi-config pull: rewriting the changed local file restores the
-# deployed content, then both files report no changes.
-$APCDEPLOY pull -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --silent
-jq -e '.mc == "dev-1"' "$MC_DIR/dev/data.json" > /dev/null
-jq -e '.mc == "stg-1"' "$MC_DIR/stg/data.json" > /dev/null
-
-# Duplicate-target detection: pointing the same -c twice must be
-# silently deduplicated; pointing two configs at the same identifier
-# (different paths) must error.
-$APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/dev/apcdeploy.yml" --silent
-mkdir -p "$MC_DIR/dup"
-cp "$MC_DIR/dev/apcdeploy.yml" "$MC_DIR/dup/apcdeploy.yml"
-cp "$MC_DIR/dev/data.json" "$MC_DIR/dup/data.json"
-if $APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/dup/apcdeploy.yml" --silent; then
-    echo "ERROR: duplicate target should have failed"
-    exit 1
-fi
-
-# Single-config commands reject multi -c with a clear error.
-if $APCDEPLOY status -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --silent 2>/dev/null; then
-    echo "ERROR: status must reject multi -c"
-    exit 1
-fi
-
-rm -rf "$MC_DIR"
-rm -f apcdeploy
+rm data.txt data.yaml data.json apcdeploy.yml apcdeploy
 echo "✅ All tests passed"

--- a/internal/aws/bake_time_started_test.go
+++ b/internal/aws/bake_time_started_test.go
@@ -1,0 +1,75 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/appconfig/types"
+)
+
+func TestBakeTimeStartedAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	earlier := now.Add(-30 * time.Second)
+
+	tests := []struct {
+		name    string
+		details *DeploymentDetails
+		want    *time.Time
+	}{
+		{
+			name:    "nil details returns nil",
+			details: nil,
+			want:    nil,
+		},
+		{
+			name:    "empty event log returns nil",
+			details: &DeploymentDetails{},
+			want:    nil,
+		},
+		{
+			name: "event log without BAKE_TIME_STARTED returns nil",
+			details: &DeploymentDetails{
+				EventLog: []types.DeploymentEvent{
+					{EventType: types.DeploymentEventTypeDeploymentStarted, OccurredAt: &earlier},
+					{EventType: types.DeploymentEventTypePercentageUpdated, OccurredAt: &now},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "BAKE_TIME_STARTED event timestamp is returned",
+			details: &DeploymentDetails{
+				EventLog: []types.DeploymentEvent{
+					{EventType: types.DeploymentEventTypeDeploymentStarted, OccurredAt: &earlier},
+					{EventType: types.DeploymentEventTypeBakeTimeStarted, OccurredAt: &now},
+				},
+			},
+			want: &now,
+		},
+		{
+			name: "BAKE_TIME_STARTED event without OccurredAt returns nil",
+			details: &DeploymentDetails{
+				EventLog: []types.DeploymentEvent{
+					{EventType: types.DeploymentEventTypeBakeTimeStarted, OccurredAt: nil},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := BakeTimeStartedAt(tt.details)
+			switch {
+			case tt.want == nil && got != nil:
+				t.Errorf("BakeTimeStartedAt() = %v, want nil", got)
+			case tt.want != nil && got == nil:
+				t.Errorf("BakeTimeStartedAt() = nil, want %v", tt.want)
+			case tt.want != nil && got != nil && !got.Equal(*tt.want):
+				t.Errorf("BakeTimeStartedAt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/aws/deployment.go
+++ b/internal/aws/deployment.go
@@ -455,7 +455,34 @@ type DeploymentDetails struct {
 	CompletedAt            *time.Time
 	PercentageComplete     float32
 	GrowthFactor           float32
+	// DeploymentDurationInMinutes is the strategy's configured deploy
+	// phase duration (integer minutes — AppConfig API constraint).
+	// AppConfig schedules the rollout to fit within this window, so
+	// the actual deploy phase always takes exactly this many minutes
+	// modulo a few seconds of state-machine overhead.
+	DeploymentDurationInMinutes int32
+	// FinalBakeTimeInMinutes is the strategy's configured bake phase
+	// duration (integer minutes — same constraint).
 	FinalBakeTimeInMinutes int32
+}
+
+// BakeTimeStartedAt returns the OccurredAt timestamp of the
+// BAKE_TIME_STARTED event in details.EventLog, or nil if no such event
+// is present (yet). AppConfig records this when the deploy phase ends
+// and the bake phase begins; subtracting StartedAt from it yields the
+// AWS-recorded deploy phase elapsed (jitter included — see
+// docs/design/output.md notes on overhead).
+func BakeTimeStartedAt(details *DeploymentDetails) *time.Time {
+	if details == nil {
+		return nil
+	}
+	for _, e := range details.EventLog {
+		if e.EventType == types.DeploymentEventTypeBakeTimeStarted && e.OccurredAt != nil {
+			t := *e.OccurredAt
+			return &t
+		}
+	}
+	return nil
 }
 
 // GetDeploymentDetails retrieves detailed information about a specific deployment
@@ -482,18 +509,19 @@ func GetDeploymentDetails(ctx context.Context, client *Client, applicationID, en
 	}
 
 	details := &DeploymentDetails{
-		DeploymentNumber:       output.DeploymentNumber,
-		ConfigurationProfileID: aws.ToString(output.ConfigurationProfileId),
-		ConfigurationVersion:   aws.ToString(output.ConfigurationVersion),
-		DeploymentStrategyID:   aws.ToString(output.DeploymentStrategyId),
-		State:                  output.State,
-		Description:            aws.ToString(output.Description),
-		EventLog:               output.EventLog,
-		StartedAt:              output.StartedAt,
-		CompletedAt:            output.CompletedAt,
-		PercentageComplete:     percentageComplete,
-		GrowthFactor:           growthFactor,
-		FinalBakeTimeInMinutes: output.FinalBakeTimeInMinutes,
+		DeploymentNumber:            output.DeploymentNumber,
+		ConfigurationProfileID:      aws.ToString(output.ConfigurationProfileId),
+		ConfigurationVersion:        aws.ToString(output.ConfigurationVersion),
+		DeploymentStrategyID:        aws.ToString(output.DeploymentStrategyId),
+		State:                       output.State,
+		Description:                 aws.ToString(output.Description),
+		EventLog:                    output.EventLog,
+		StartedAt:                   output.StartedAt,
+		CompletedAt:                 output.CompletedAt,
+		PercentageComplete:          percentageComplete,
+		GrowthFactor:                growthFactor,
+		DeploymentDurationInMinutes: output.DeploymentDurationInMinutes,
+		FinalBakeTimeInMinutes:      output.FinalBakeTimeInMinutes,
 	}
 
 	return details, nil

--- a/internal/aws/deployment.go
+++ b/internal/aws/deployment.go
@@ -470,8 +470,7 @@ type DeploymentDetails struct {
 // BAKE_TIME_STARTED event in details.EventLog, or nil if no such event
 // is present (yet). AppConfig records this when the deploy phase ends
 // and the bake phase begins; subtracting StartedAt from it yields the
-// AWS-recorded deploy phase elapsed (jitter included — see
-// docs/design/output.md notes on overhead).
+// AWS-recorded deploy phase elapsed (jitter included).
 func BakeTimeStartedAt(details *DeploymentDetails) *time.Time {
 	if details == nil {
 		return nil

--- a/internal/batch/loader.go
+++ b/internal/batch/loader.go
@@ -1,0 +1,80 @@
+package batch
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/koh-sh/apcdeploy/internal/config"
+)
+
+// ErrDuplicateTarget is returned when two distinct config files resolve to
+// the same `region/app/profile/env` 4-tuple. It is exposed as a sentinel so
+// command-layer code can react with a tailored exit message
+// (multi-config.md §6.4).
+var ErrDuplicateTarget = errors.New("duplicate target")
+
+// LoadAll reads, parses, and validates every config path supplied on the
+// command line, returning one Target per *unique* path in argument order
+// (multi-config.md §7.2).
+//
+// The function is the single chokepoint for "事前エラー" defined in
+// multi-config.md §10.1: any load failure aborts the batch before the
+// orchestrator runs a single AWS call. The first error encountered is
+// returned with the offending path included so the user can act on it.
+//
+// Path-level dedup (`./x.yml` vs `x.yml`, multi-config.md F-08) silently
+// collapses duplicates to one Target. Identifier-level duplicates
+// (multi-config.md F-07) are an explicit error and surface both source
+// paths.
+func LoadAll(paths []string) ([]*Target, error) {
+	if len(paths) == 0 {
+		return nil, errors.New("at least one --config path is required")
+	}
+
+	targets := make([]*Target, 0, len(paths))
+	// seenAbs collapses syntactically distinct paths that point at the
+	// same file (F-08). Storing the absolute form is enough; we map back
+	// to the original path string from the Target itself for messaging.
+	seenAbs := make(map[string]struct{}, len(paths))
+	// byID lets us pinpoint the *other* path involved in a duplicate
+	// (F-07) without scanning targets twice.
+	byID := make(map[string]*Target, len(paths))
+
+	for _, p := range paths {
+		abs, err := filepath.Abs(filepath.Clean(p))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", p, err)
+		}
+		if _, dup := seenAbs[abs]; dup {
+			continue
+		}
+		seenAbs[abs] = struct{}{}
+
+		cfg, err := config.LoadConfig(p)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", p, err)
+		}
+
+		// At load time the only region we know is whatever the user put
+		// in the yml. The CLI default-region fallback only applies once
+		// an AWS client is built, by which point dedup has already run.
+		// Configs that omit `region:` therefore collide on identifier —
+		// that's the documented behavior (multi-config.md §6.2: specify
+		// region when using multi-config).
+		id := config.Identifier("", cfg)
+
+		if prev, dup := byID[id]; dup {
+			return nil, fmt.Errorf(
+				"%w: %q is also defined in %q (identifier: %s)",
+				ErrDuplicateTarget, p, prev.Path, id,
+			)
+		}
+
+		t := &Target{Path: p, Config: cfg, Identifier: id}
+		byID[id] = t
+		targets = append(targets, t)
+	}
+
+	return targets, nil
+}

--- a/internal/batch/loader.go
+++ b/internal/batch/loader.go
@@ -39,7 +39,7 @@ func LoadAll(paths []string) ([]*Target, error) {
 	byID := make(map[string]*Target, len(paths))
 
 	for _, p := range paths {
-		abs, err := filepath.Abs(filepath.Clean(p))
+		abs, err := filepath.Abs(p)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", p, err)
 		}

--- a/internal/batch/loader.go
+++ b/internal/batch/loader.go
@@ -10,23 +10,20 @@ import (
 
 // ErrDuplicateTarget is returned when two distinct config files resolve to
 // the same `region/app/profile/env` 4-tuple. It is exposed as a sentinel so
-// command-layer code can react with a tailored exit message
-// (multi-config.md §6.4).
+// command-layer code can react with a tailored exit message.
 var ErrDuplicateTarget = errors.New("duplicate target")
 
 // LoadAll reads, parses, and validates every config path supplied on the
-// command line, returning one Target per *unique* path in argument order
-// (multi-config.md §7.2).
+// command line, returning one Target per *unique* path in argument order.
 //
-// The function is the single chokepoint for "事前エラー" defined in
-// multi-config.md §10.1: any load failure aborts the batch before the
-// orchestrator runs a single AWS call. The first error encountered is
-// returned with the offending path included so the user can act on it.
+// The function is the single chokepoint for pre-flight load errors: any
+// load failure aborts the batch before the orchestrator runs a single
+// AWS call. The first error encountered is returned with the offending
+// path included so the user can act on it.
 //
-// Path-level dedup (`./x.yml` vs `x.yml`, multi-config.md F-08) silently
-// collapses duplicates to one Target. Identifier-level duplicates
-// (multi-config.md F-07) are an explicit error and surface both source
-// paths.
+// Path-level dedup silently collapses duplicates to one Target.
+// Identifier-level duplicates are an explicit error and surface both
+// source paths.
 func LoadAll(paths []string) ([]*Target, error) {
 	if len(paths) == 0 {
 		return nil, errors.New("at least one --config path is required")
@@ -34,11 +31,11 @@ func LoadAll(paths []string) ([]*Target, error) {
 
 	targets := make([]*Target, 0, len(paths))
 	// seenAbs collapses syntactically distinct paths that point at the
-	// same file (F-08). Storing the absolute form is enough; we map back
-	// to the original path string from the Target itself for messaging.
+	// same file. Storing the absolute form is enough; we map back to the
+	// original path string from the Target itself for messaging.
 	seenAbs := make(map[string]struct{}, len(paths))
 	// byID lets us pinpoint the *other* path involved in a duplicate
-	// (F-07) without scanning targets twice.
+	// without scanning targets twice.
 	byID := make(map[string]*Target, len(paths))
 
 	for _, p := range paths {
@@ -60,8 +57,8 @@ func LoadAll(paths []string) ([]*Target, error) {
 		// in the yml. The CLI default-region fallback only applies once
 		// an AWS client is built, by which point dedup has already run.
 		// Configs that omit `region:` therefore collide on identifier —
-		// that's the documented behavior (multi-config.md §6.2: specify
-		// region when using multi-config).
+		// that's the documented behavior: specify region when using
+		// multi-config.
 		id := config.Identifier("", cfg)
 
 		if prev, dup := byID[id]; dup {

--- a/internal/batch/loader_test.go
+++ b/internal/batch/loader_test.go
@@ -1,0 +1,203 @@
+package batch
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeYML is a small helper that drops a YAML file into dir and returns
+// its absolute path. Each test gets its own t.TempDir() so file collisions
+// across cases are impossible.
+func writeYML(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func goodYML(region, app, profile, env, dataFile string) string {
+	return strings.Join([]string{
+		"region: " + region,
+		"application: " + app,
+		"configuration_profile: " + profile,
+		"environment: " + env,
+		"data_file: " + dataFile,
+	}, "\n") + "\n"
+}
+
+func TestLoadAll_SinglePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := writeYML(t, dir, "apcdeploy.yml", goodYML("us-east-1", "app", "profile", "prod", "data.json"))
+	writeYML(t, dir, "data.json", `{"foo":1}`)
+
+	targets, err := LoadAll([]string{cfg})
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("len(targets) = %d, want 1", len(targets))
+	}
+	if got, want := targets[0].Identifier, "us-east-1/app/profile/prod"; got != want {
+		t.Errorf("Identifier = %q, want %q", got, want)
+	}
+	if targets[0].Path != cfg {
+		t.Errorf("Path = %q, want input verbatim", targets[0].Path)
+	}
+}
+
+func TestLoadAll_PreservesArgumentOrder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	a := writeYML(t, dir, "a/apcdeploy.yml", goodYML("us-east-1", "app", "profile", "dev", "data.json"))
+	b := writeYML(t, dir, "b/apcdeploy.yml", goodYML("us-east-1", "app", "profile", "stg", "data.json"))
+	c := writeYML(t, dir, "c/apcdeploy.yml", goodYML("us-east-1", "app", "profile", "prod", "data.json"))
+	for _, d := range []string{"a", "b", "c"} {
+		writeYML(t, dir, d+"/data.json", `{}`)
+	}
+
+	targets, err := LoadAll([]string{c, a, b})
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	got := []string{targets[0].Identifier, targets[1].Identifier, targets[2].Identifier}
+	want := []string{
+		"us-east-1/app/profile/prod",
+		"us-east-1/app/profile/dev",
+		"us-east-1/app/profile/stg",
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("targets[%d].Identifier = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLoadAll_DeduplicatesEquivalentPaths(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := writeYML(t, dir, "apcdeploy.yml", goodYML("us-east-1", "app", "profile", "prod", "data.json"))
+	writeYML(t, dir, "data.json", `{}`)
+
+	// Same file referenced via three syntactically different absolute
+	// forms — the loader must collapse them to one Target
+	// (multi-config.md F-08). We avoid t.Chdir/os.Chdir here on purpose
+	// because t.Parallel() makes process-global cwd mutation hostile to
+	// neighbouring tests.
+	withDot := filepath.Join(filepath.Dir(cfg), ".", filepath.Base(cfg))
+	withDotDot := filepath.Join(filepath.Dir(cfg), "..", filepath.Base(filepath.Dir(cfg)), filepath.Base(cfg))
+
+	paths := []string{cfg, withDot, withDotDot}
+	targets, err := LoadAll(paths)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("len(targets) = %d, want 1 (deduplicated)", len(targets))
+	}
+}
+
+func TestLoadAll_DuplicateIdentifierIsError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	a := writeYML(t, dir, "a/apcdeploy.yml", goodYML("us-east-1", "app", "profile", "prod", "data.json"))
+	b := writeYML(t, dir, "b/apcdeploy.yml", goodYML("us-east-1", "app", "profile", "prod", "data.json"))
+	for _, d := range []string{"a", "b"} {
+		writeYML(t, dir, d+"/data.json", `{}`)
+	}
+
+	_, err := LoadAll([]string{a, b})
+	if err == nil {
+		t.Fatal("LoadAll: want error for duplicate identifier, got nil")
+	}
+	if !errors.Is(err, ErrDuplicateTarget) {
+		t.Errorf("err = %v, want errors.Is(ErrDuplicateTarget)", err)
+	}
+	// Both paths should appear in the message so the user can locate
+	// the conflict (multi-config.md §6.4).
+	msg := err.Error()
+	if !strings.Contains(msg, a) || !strings.Contains(msg, b) {
+		t.Errorf("err message must mention both paths, got: %s", msg)
+	}
+	if !strings.Contains(msg, "us-east-1/app/profile/prod") {
+		t.Errorf("err message must mention identifier, got: %s", msg)
+	}
+}
+
+func TestLoadAll_EmptyPathsIsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadAll(nil)
+	if err == nil {
+		t.Fatal("LoadAll(nil): want error, got nil")
+	}
+	_, err = LoadAll([]string{})
+	if err == nil {
+		t.Fatal("LoadAll([]): want error, got nil")
+	}
+}
+
+func TestLoadAll_MissingFileSurfacesPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	good := writeYML(t, dir, "good.yml", goodYML("us-east-1", "app", "profile", "prod", "data.json"))
+	writeYML(t, dir, "data.json", `{}`)
+	missing := filepath.Join(dir, "no-such.yml")
+
+	_, err := LoadAll([]string{good, missing})
+	if err == nil {
+		t.Fatal("LoadAll: want error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("err must mention the failing path %q, got: %v", missing, err)
+	}
+}
+
+func TestLoadAll_InvalidYAMLSurfacesPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bad := writeYML(t, dir, "bad.yml", "::: not yaml :::")
+
+	_, err := LoadAll([]string{bad})
+	if err == nil {
+		t.Fatal("LoadAll: want error for invalid yaml, got nil")
+	}
+	if !strings.Contains(err.Error(), bad) {
+		t.Errorf("err must mention the failing path %q, got: %v", bad, err)
+	}
+}
+
+func TestLoadAll_DuplicateRespectsRegionDifference(t *testing.T) {
+	t.Parallel()
+
+	// Same app/profile/env in different regions are distinct targets;
+	// dedup must NOT collapse them (multi-config.md §6.2).
+	dir := t.TempDir()
+	a := writeYML(t, dir, "a/apcdeploy.yml", goodYML("us-east-1", "app", "profile", "prod", "data.json"))
+	b := writeYML(t, dir, "b/apcdeploy.yml", goodYML("eu-west-1", "app", "profile", "prod", "data.json"))
+	for _, d := range []string{"a", "b"} {
+		writeYML(t, dir, d+"/data.json", `{}`)
+	}
+
+	targets, err := LoadAll([]string{a, b})
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("len(targets) = %d, want 2", len(targets))
+	}
+}

--- a/internal/batch/loader_test.go
+++ b/internal/batch/loader_test.go
@@ -91,10 +91,9 @@ func TestLoadAll_DeduplicatesEquivalentPaths(t *testing.T) {
 	writeYML(t, dir, "data.json", `{}`)
 
 	// Same file referenced via three syntactically different absolute
-	// forms — the loader must collapse them to one Target
-	// (multi-config.md F-08). We avoid t.Chdir/os.Chdir here on purpose
-	// because t.Parallel() makes process-global cwd mutation hostile to
-	// neighbouring tests.
+	// forms — the loader must collapse them to one Target. We avoid
+	// t.Chdir/os.Chdir here on purpose because t.Parallel() makes
+	// process-global cwd mutation hostile to neighbouring tests.
 	withDot := filepath.Join(filepath.Dir(cfg), ".", filepath.Base(cfg))
 	withDotDot := filepath.Join(filepath.Dir(cfg), "..", filepath.Base(filepath.Dir(cfg)), filepath.Base(cfg))
 
@@ -126,7 +125,7 @@ func TestLoadAll_DuplicateIdentifierIsError(t *testing.T) {
 		t.Errorf("err = %v, want errors.Is(ErrDuplicateTarget)", err)
 	}
 	// Both paths should appear in the message so the user can locate
-	// the conflict (multi-config.md §6.4).
+	// the conflict.
 	msg := err.Error()
 	if !strings.Contains(msg, a) || !strings.Contains(msg, b) {
 		t.Errorf("err message must mention both paths, got: %s", msg)
@@ -185,7 +184,7 @@ func TestLoadAll_DuplicateRespectsRegionDifference(t *testing.T) {
 	t.Parallel()
 
 	// Same app/profile/env in different regions are distinct targets;
-	// dedup must NOT collapse them (multi-config.md §6.2).
+	// dedup must NOT collapse them.
 	dir := t.TempDir()
 	a := writeYML(t, dir, "a/apcdeploy.yml", goodYML("us-east-1", "app", "profile", "prod", "data.json"))
 	b := writeYML(t, dir, "b/apcdeploy.yml", goodYML("eu-west-1", "app", "profile", "prod", "data.json"))

--- a/internal/batch/orchestrator.go
+++ b/internal/batch/orchestrator.go
@@ -192,6 +192,17 @@ func (o *Orchestrator) Run(ctx context.Context) (Summary, error) {
 	return summary, nil
 }
 
+// NewTargetReporter returns a TargetReporter that drives a single row of
+// an existing Targets handle. Used by single-target executor entry points
+// (e.g. pull.Executor.Execute) that share their per-target body with the
+// orchestrator path — both routes need the same TargetReporter shape.
+//
+// The returned view is NOT goroutine-safe by itself, but the underlying
+// Targets handle is — each caller should own its own view.
+func NewTargetReporter(tg reporter.Targets, id string) reporter.TargetReporter {
+	return &targetView{inner: tg, id: id}
+}
+
 // targetView is a per-target wrapper around the shared reporter.Targets
 // handle. Each goroutine owns one view, so no synchronisation is required
 // inside the view itself.

--- a/internal/batch/orchestrator.go
+++ b/internal/batch/orchestrator.go
@@ -19,20 +19,19 @@ import (
 //
 // The context is the parent passed to Orchestrator.Run; per-target
 // timeouts (e.g. run's --timeout) are the executor's responsibility, not
-// the orchestrator's (multi-config.md §7.4).
+// the orchestrator's.
 type ExecuteFunc func(ctx context.Context, t *Target, tr reporter.TargetReporter) error
 
 // TargetError pairs a failed Target with the underlying error so the
-// command layer can render the post-run "Errors:" section
-// (docs/design/output.md §8.3).
+// command layer can render the post-run "Errors:" section.
 type TargetError struct {
 	Identifier string
 	Path       string
 	Err        error
 }
 
-// Summary aggregates per-target outcomes for the post-run line described
-// in docs/design/output.md §8.2 (`N ok, N no-op, N failed [(elapsed)]`).
+// Summary aggregates per-target outcomes for the post-run line:
+// `N ok, N no-op, N failed [(elapsed)]`.
 //
 // Skipped is broken out from NoOp so that callers (and tests) can tell
 // fail-fast skips from "no changes" no-ops. The aggregate "no-op" column
@@ -48,7 +47,7 @@ type Summary struct {
 
 // Orchestrator drives a slice of pre-loaded Targets through one shared
 // Reporter.Targets handle, in parallel, with optional fail-fast or
-// continue-on-error semantics (multi-config.md §7).
+// continue-on-error semantics.
 //
 // The zero value is not usable — Targets, Reporter, and Execute MUST be
 // set. Parallel <= 0 means "all at once" (i.e. len(Targets)).
@@ -62,18 +61,16 @@ type Orchestrator struct {
 
 // Run drives every Target through Execute and returns a Summary plus an
 // aggregate error (non-nil if any target failed, regardless of
-// ContinueOnError — exit code 1 is the contract for any failure,
-// multi-config.md §10.1).
+// ContinueOnError — exit code 1 is the contract for any failure).
 //
 // Concurrency model:
 //   - One goroutine per Target, gated by a buffered semaphore of size
 //     `parallel` so at most `parallel` targets execute simultaneously.
 //   - Argument start order is preserved: Targets[i] is launched before
-//     Targets[i+1]. With Parallel=1 this produces strict serial order
-//     (multi-config.md §7.2).
-//   - Fail-fast does NOT cancel running targets (§7.3). It only prevents
-//     further targets from starting; queued targets are reported via
-//     Targets.Skip with reason "skipped (fail-fast)".
+//     Targets[i+1]. With Parallel=1 this produces strict serial order.
+//   - Fail-fast does NOT cancel running targets. It only prevents further
+//     targets from starting; queued targets are reported via Targets.Skip
+//     with reason "skipped (fail-fast)".
 func (o *Orchestrator) Run(ctx context.Context) (Summary, error) {
 	if len(o.Targets) == 0 {
 		return Summary{}, errors.New("orchestrator: no targets")
@@ -121,7 +118,7 @@ func (o *Orchestrator) Run(ctx context.Context) (Summary, error) {
 	// channel up-front and rely on `for range work` for clean worker
 	// shutdown. The channel is FIFO, so workers pull targets in
 	// argument order even though completion order is undefined under
-	// parallel >= 2 (multi-config.md §7.2).
+	// parallel >= 2.
 	work := make(chan workItem, len(o.Targets))
 	for i, t := range o.Targets {
 		work <- workItem{idx: i, target: t}

--- a/internal/batch/orchestrator.go
+++ b/internal/batch/orchestrator.go
@@ -1,0 +1,248 @@
+package batch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/koh-sh/apcdeploy/internal/reporter"
+)
+
+// ExecuteFunc is the per-target callback the Orchestrator invokes once for
+// every loaded Target. Implementations MUST drive the supplied
+// TargetReporter through to a terminal state (Done / Skip / Fail) before
+// returning. Returning a non-nil error counts as a failure even if Fail was
+// not called — the orchestrator will defensively call Fail in that case so
+// the row never stays in "running" forever.
+//
+// The context is the parent passed to Orchestrator.Run; per-target
+// timeouts (e.g. run's --timeout) are the executor's responsibility, not
+// the orchestrator's (multi-config.md §7.4).
+type ExecuteFunc func(ctx context.Context, t *Target, tr reporter.TargetReporter) error
+
+// TargetError pairs a failed Target with the underlying error so the
+// command layer can render the post-run "Errors:" section
+// (docs/design/output.md §8.3).
+type TargetError struct {
+	Identifier string
+	Path       string
+	Err        error
+}
+
+// Summary aggregates per-target outcomes for the post-run line described
+// in docs/design/output.md §8.2 (`N ok, N no-op, N failed [(elapsed)]`).
+//
+// Skipped is broken out from NoOp so that callers (and tests) can tell
+// fail-fast skips from "no changes" no-ops. The aggregate "no-op" column
+// shown to the user is NoOp + Skipped.
+type Summary struct {
+	OK      int
+	NoOp    int
+	Skipped int
+	Failed  int
+	Errors  []TargetError
+	Elapsed time.Duration
+}
+
+// Orchestrator drives a slice of pre-loaded Targets through one shared
+// Reporter.Targets handle, in parallel, with optional fail-fast or
+// continue-on-error semantics (multi-config.md §7).
+//
+// The zero value is not usable — Targets, Reporter, and Execute MUST be
+// set. Parallel <= 0 means "all at once" (i.e. len(Targets)).
+type Orchestrator struct {
+	Targets         []*Target
+	Parallel        int
+	ContinueOnError bool
+	Reporter        reporter.Reporter
+	Execute         ExecuteFunc
+}
+
+// Run drives every Target through Execute and returns a Summary plus an
+// aggregate error (non-nil if any target failed, regardless of
+// ContinueOnError — exit code 1 is the contract for any failure,
+// multi-config.md §10.1).
+//
+// Concurrency model:
+//   - One goroutine per Target, gated by a buffered semaphore of size
+//     `parallel` so at most `parallel` targets execute simultaneously.
+//   - Argument start order is preserved: Targets[i] is launched before
+//     Targets[i+1]. With Parallel=1 this produces strict serial order
+//     (multi-config.md §7.2).
+//   - Fail-fast does NOT cancel running targets (§7.3). It only prevents
+//     further targets from starting; queued targets are reported via
+//     Targets.Skip with reason "skipped (fail-fast)".
+func (o *Orchestrator) Run(ctx context.Context) (Summary, error) {
+	if len(o.Targets) == 0 {
+		return Summary{}, errors.New("orchestrator: no targets")
+	}
+	if o.Reporter == nil {
+		return Summary{}, errors.New("orchestrator: Reporter is required")
+	}
+	if o.Execute == nil {
+		return Summary{}, errors.New("orchestrator: Execute is required")
+	}
+
+	parallel := o.Parallel
+	if parallel <= 0 || parallel > len(o.Targets) {
+		parallel = len(o.Targets)
+	}
+
+	ids := make([]string, len(o.Targets))
+	for i, t := range o.Targets {
+		ids[i] = t.Identifier
+	}
+	tg := o.Reporter.Targets(ids)
+	defer tg.Close()
+
+	start := time.Now()
+
+	// failed flag short-circuits scheduling under fail-fast. It is only
+	// checked when ContinueOnError is false. Protected by mu along with
+	// errors and the Skipped count for any target rejected on entry.
+	var (
+		mu     sync.Mutex
+		failed bool
+		errs   []TargetError
+	)
+
+	views := make([]*targetView, len(o.Targets))
+	for i, t := range o.Targets {
+		views[i] = &targetView{inner: tg, id: t.Identifier}
+	}
+
+	type workItem struct {
+		idx    int
+		target *Target
+	}
+	// Buffered so the producer never blocks: this lets us close the
+	// channel up-front and rely on `for range work` for clean worker
+	// shutdown. The channel is FIFO, so workers pull targets in
+	// argument order even though completion order is undefined under
+	// parallel >= 2 (multi-config.md §7.2).
+	work := make(chan workItem, len(o.Targets))
+	for i, t := range o.Targets {
+		work <- workItem{idx: i, target: t}
+	}
+	close(work)
+
+	var wg sync.WaitGroup
+	for w := 0; w < parallel; w++ {
+		wg.Go(func() {
+			for item := range work {
+				if !o.ContinueOnError {
+					mu.Lock()
+					skip := failed
+					mu.Unlock()
+					if skip {
+						views[item.idx].markSkippedFailFast()
+						tg.Skip(item.target.Identifier, "skipped (fail-fast)")
+						continue
+					}
+				}
+
+				err := o.Execute(ctx, item.target, views[item.idx])
+				if err != nil {
+					// If the executor returned an error but never
+					// called Fail (contract violation), surface it to
+					// the row so the user sees a terminal state.
+					if views[item.idx].state == statePending {
+						views[item.idx].Fail(err)
+					}
+					mu.Lock()
+					failed = true
+					errs = append(errs, TargetError{
+						Identifier: item.target.Identifier,
+						Path:       item.target.Path,
+						Err:        err,
+					})
+					mu.Unlock()
+				}
+			}
+		})
+	}
+
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	summary := Summary{Elapsed: elapsed, Errors: errs}
+	for _, v := range views {
+		switch v.state {
+		case stateOK:
+			summary.OK++
+		case stateNoOp:
+			summary.NoOp++
+		case stateFailed:
+			summary.Failed++
+		case stateSkipped:
+			summary.Skipped++
+		case statePending:
+			// Executor returned nil without setting a terminal state. Not
+			// expected, but count it as OK so the summary at least adds
+			// up to len(Targets); the contract violation is its own bug.
+			summary.OK++
+		}
+	}
+
+	if len(errs) > 0 {
+		return summary, fmt.Errorf("%d target(s) failed", len(errs))
+	}
+	return summary, nil
+}
+
+// targetView is a per-target wrapper around the shared reporter.Targets
+// handle. Each goroutine owns one view, so no synchronisation is required
+// inside the view itself.
+type targetView struct {
+	inner reporter.Targets
+	id    string
+	state targetState
+}
+
+type targetState int
+
+const (
+	statePending targetState = iota
+	stateOK
+	stateNoOp
+	stateFailed
+	stateSkipped
+)
+
+func (v *targetView) SetPhase(phase, detail string) {
+	v.inner.SetPhase(v.id, phase, detail)
+}
+
+func (v *targetView) SetProgress(percent float64, eta time.Duration) {
+	v.inner.SetProgress(v.id, percent, eta)
+}
+
+func (v *targetView) Done(summary string) {
+	if v.state == statePending {
+		v.state = stateOK
+	}
+	v.inner.Done(v.id, summary)
+}
+
+func (v *targetView) Skip(reason string) {
+	if v.state == statePending {
+		v.state = stateNoOp
+	}
+	v.inner.Skip(v.id, reason)
+}
+
+func (v *targetView) Fail(err error) {
+	if v.state == statePending {
+		v.state = stateFailed
+	}
+	v.inner.Fail(v.id, err)
+}
+
+// markSkippedFailFast records a fail-fast skip without round-tripping
+// through Skip(). The orchestrator already called tg.Skip directly so we
+// only need to update the local counter.
+func (v *targetView) markSkippedFailFast() {
+	v.state = stateSkipped
+}

--- a/internal/batch/orchestrator_test.go
+++ b/internal/batch/orchestrator_test.go
@@ -1,0 +1,270 @@
+package batch
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/koh-sh/apcdeploy/internal/config"
+	"github.com/koh-sh/apcdeploy/internal/reporter"
+	reportertesting "github.com/koh-sh/apcdeploy/internal/reporter/testing"
+)
+
+func makeTargets(ids ...string) []*Target {
+	out := make([]*Target, len(ids))
+	for i, id := range ids {
+		out[i] = &Target{
+			Path:       id + ".yml",
+			Identifier: id,
+			Config:     &config.Config{},
+		}
+	}
+	return out
+}
+
+func TestOrchestrator_AllSucceed(t *testing.T) {
+	t.Parallel()
+
+	rep := &reportertesting.MockReporter{}
+	targets := makeTargets("a", "b", "c")
+
+	o := &Orchestrator{
+		Targets:  targets,
+		Reporter: rep,
+		Execute: func(ctx context.Context, tgt *Target, tr reporter.TargetReporter) error {
+			tr.Done("done " + tgt.Identifier)
+			return nil
+		},
+	}
+	summary, err := o.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.OK != 3 || summary.NoOp != 0 || summary.Failed != 0 {
+		t.Errorf("summary = %+v, want OK=3", summary)
+	}
+	if len(rep.TargetsCalls) != 1 || !rep.TargetsCalls[0].Closed {
+		t.Errorf("Targets must be opened once and Closed; got %+v", rep.TargetsCalls)
+	}
+}
+
+func TestOrchestrator_NoOpCounted(t *testing.T) {
+	t.Parallel()
+
+	rep := &reportertesting.MockReporter{}
+	targets := makeTargets("a", "b")
+
+	o := &Orchestrator{
+		Targets:  targets,
+		Reporter: rep,
+		Execute: func(ctx context.Context, tgt *Target, tr reporter.TargetReporter) error {
+			tr.Skip("no changes")
+			return nil
+		},
+	}
+	summary, err := o.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.OK != 0 || summary.NoOp != 2 || summary.Failed != 0 {
+		t.Errorf("summary = %+v, want NoOp=2", summary)
+	}
+}
+
+func TestOrchestrator_FailFastSkipsRemaining(t *testing.T) {
+	t.Parallel()
+
+	rep := &reportertesting.MockReporter{}
+	targets := makeTargets("a", "b", "c", "d")
+
+	// Block "a" so the failure (from "b") propagates while "c"/"d" are
+	// still queued. Parallel=2 means at most a+b run concurrently;
+	// c/d should never start.
+	gateA := make(chan struct{})
+	var executed atomic.Int32
+
+	o := &Orchestrator{
+		Targets:  targets,
+		Parallel: 2,
+		Reporter: rep,
+		Execute: func(ctx context.Context, tgt *Target, tr reporter.TargetReporter) error {
+			executed.Add(1)
+			switch tgt.Identifier {
+			case "a":
+				<-gateA
+				tr.Done("ok")
+				return nil
+			case "b":
+				err := errors.New("boom")
+				tr.Fail(err)
+				return err
+			default:
+				t.Errorf("target %s should not have executed under fail-fast", tgt.Identifier)
+				tr.Done("unexpected")
+				return nil
+			}
+		},
+	}
+
+	doneCh := make(chan struct{})
+	var summary Summary
+	var runErr error
+	go func() {
+		summary, runErr = o.Run(context.Background())
+		close(doneCh)
+	}()
+
+	// Wait for "b" to fail.
+	deadline := time.Now().Add(2 * time.Second)
+	for executed.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Release "a" so the orchestrator can finish.
+	close(gateA)
+	<-doneCh
+
+	if runErr == nil {
+		t.Fatal("Run should return non-nil error when a target fails")
+	}
+	if summary.Failed != 1 {
+		t.Errorf("summary.Failed = %d, want 1", summary.Failed)
+	}
+	if summary.Skipped != 2 {
+		t.Errorf("summary.Skipped = %d, want 2 (c,d skipped under fail-fast)", summary.Skipped)
+	}
+	if executed.Load() != 2 {
+		t.Errorf("executed = %d, want 2 (only a,b executed)", executed.Load())
+	}
+}
+
+func TestOrchestrator_ContinueOnErrorRunsAll(t *testing.T) {
+	t.Parallel()
+
+	rep := &reportertesting.MockReporter{}
+	targets := makeTargets("a", "b", "c")
+
+	o := &Orchestrator{
+		Targets:         targets,
+		Parallel:        1,
+		ContinueOnError: true,
+		Reporter:        rep,
+		Execute: func(ctx context.Context, tgt *Target, tr reporter.TargetReporter) error {
+			if tgt.Identifier == "b" {
+				err := errors.New("only b fails")
+				tr.Fail(err)
+				return err
+			}
+			tr.Done("ok")
+			return nil
+		},
+	}
+	summary, err := o.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run should still return error so exit code is non-zero")
+	}
+	if summary.OK != 2 || summary.Failed != 1 || summary.Skipped != 0 {
+		t.Errorf("summary = %+v, want OK=2 Failed=1 Skipped=0", summary)
+	}
+	if len(summary.Errors) != 1 || summary.Errors[0].Identifier != "b" {
+		t.Errorf("summary.Errors = %+v, want one entry for b", summary.Errors)
+	}
+}
+
+func TestOrchestrator_PreservesArgumentStartOrder(t *testing.T) {
+	t.Parallel()
+
+	rep := &reportertesting.MockReporter{}
+	targets := makeTargets("a", "b", "c", "d", "e")
+
+	var (
+		mu      sync.Mutex
+		started []string
+	)
+	o := &Orchestrator{
+		Targets:  targets,
+		Parallel: 1, // serial — start order == finish order
+		Reporter: rep,
+		Execute: func(ctx context.Context, tgt *Target, tr reporter.TargetReporter) error {
+			mu.Lock()
+			started = append(started, tgt.Identifier)
+			mu.Unlock()
+			tr.Done("ok")
+			return nil
+		},
+	}
+	if _, err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := []string{"a", "b", "c", "d", "e"}
+	if len(started) != len(want) {
+		t.Fatalf("started = %v, want %v", started, want)
+	}
+	for i := range want {
+		if started[i] != want[i] {
+			t.Errorf("started[%d] = %q, want %q", i, started[i], want[i])
+		}
+	}
+}
+
+func TestOrchestrator_FailureWithoutFailCallStillCounted(t *testing.T) {
+	t.Parallel()
+
+	// An executor that returns an error without calling tr.Fail is a
+	// contract violation, but the orchestrator must still record the
+	// failure and surface the error so the row doesn't render forever.
+	rep := &reportertesting.MockReporter{}
+	targets := makeTargets("a")
+
+	o := &Orchestrator{
+		Targets:  targets,
+		Reporter: rep,
+		Execute: func(ctx context.Context, tgt *Target, tr reporter.TargetReporter) error {
+			return errors.New("naked error")
+		},
+	}
+	summary, err := o.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run should propagate executor error")
+	}
+	if summary.Failed != 1 {
+		t.Errorf("summary.Failed = %d, want 1", summary.Failed)
+	}
+}
+
+func TestOrchestrator_DefaultParallelIsAll(t *testing.T) {
+	t.Parallel()
+
+	rep := &reportertesting.MockReporter{}
+	targets := makeTargets("a", "b", "c", "d")
+
+	var concurrent atomic.Int32
+	var maxSeen atomic.Int32
+
+	o := &Orchestrator{
+		Targets:  targets,
+		Reporter: rep,
+		// Parallel left as 0 → defaults to len(Targets).
+		Execute: func(ctx context.Context, tgt *Target, tr reporter.TargetReporter) error {
+			cur := concurrent.Add(1)
+			defer concurrent.Add(-1)
+			for {
+				prev := maxSeen.Load()
+				if cur <= prev || maxSeen.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+			time.Sleep(20 * time.Millisecond)
+			tr.Done("ok")
+			return nil
+		},
+	}
+	if _, err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if maxSeen.Load() < 2 {
+		t.Errorf("maxSeen = %d, want >= 2 (default Parallel should run targets concurrently)", maxSeen.Load())
+	}
+}

--- a/internal/batch/target.go
+++ b/internal/batch/target.go
@@ -1,0 +1,41 @@
+// Package batch coordinates the multi-config (`-c` repeated) execution
+// path used by run / diff / pull. See docs/design/multi-config.md.
+//
+// The package owns two responsibilities:
+//
+//   - LoadAll: pre-load and validate every config given on the command
+//     line before any AWS work begins, and surface load-time errors as a
+//     single batch (multi-config.md §9 / §10.1 "事前エラー").
+//
+//   - Orchestrator: drive the loaded targets through executor functions,
+//     in parallel by default, with optional fail-fast / continue-on-error
+//     semantics (multi-config.md §7).
+//
+// N=1 and N=N flow through the same code path; the orchestrator simply
+// runs a single goroutine when only one target is loaded
+// (multi-config.md §3 F-10).
+package batch
+
+import (
+	"github.com/koh-sh/apcdeploy/internal/config"
+)
+
+// Target is one loaded `-c` argument: the original path (preserved for
+// error messages — multi-config.md §6.3), the loaded Config, and the
+// canonical identifier used for duplicate detection and progress
+// rendering.
+type Target struct {
+	// Path is the path string as supplied on the command line. It is
+	// kept verbatim so error messages refer back to what the user typed
+	// ("./envs/dev.yml") rather than the absolute form used internally
+	// for dedup.
+	Path string
+
+	// Config is the loaded and validated configuration.
+	Config *config.Config
+
+	// Identifier is the "region/app/profile/env" 4-tuple
+	// (multi-config.md §6.1). Computed from Config at load time so the
+	// orchestrator and Reporter agree on the row label.
+	Identifier string
+}

--- a/internal/batch/target.go
+++ b/internal/batch/target.go
@@ -1,19 +1,18 @@
 // Package batch coordinates the multi-config (`-c` repeated) execution
-// path used by run / diff / pull. See docs/design/multi-config.md.
+// path used by run / diff / pull.
 //
 // The package owns two responsibilities:
 //
 //   - LoadAll: pre-load and validate every config given on the command
 //     line before any AWS work begins, and surface load-time errors as a
-//     single batch (multi-config.md §9 / §10.1 "事前エラー").
+//     single batch.
 //
 //   - Orchestrator: drive the loaded targets through executor functions,
 //     in parallel by default, with optional fail-fast / continue-on-error
-//     semantics (multi-config.md §7).
+//     semantics.
 //
 // N=1 and N=N flow through the same code path; the orchestrator simply
-// runs a single goroutine when only one target is loaded
-// (multi-config.md §3 F-10).
+// runs a single goroutine when only one target is loaded.
 package batch
 
 import (
@@ -21,9 +20,8 @@ import (
 )
 
 // Target is one loaded `-c` argument: the original path (preserved for
-// error messages — multi-config.md §6.3), the loaded Config, and the
-// canonical identifier used for duplicate detection and progress
-// rendering.
+// error messages), the loaded Config, and the canonical identifier used
+// for duplicate detection and progress rendering.
 type Target struct {
 	// Path is the path string as supplied on the command line. It is
 	// kept verbatim so error messages refer back to what the user typed
@@ -34,8 +32,8 @@ type Target struct {
 	// Config is the loaded and validated configuration.
 	Config *config.Config
 
-	// Identifier is the "region/app/profile/env" 4-tuple
-	// (multi-config.md §6.1). Computed from Config at load time so the
-	// orchestrator and Reporter agree on the row label.
+	// Identifier is the "region/app/profile/env" 4-tuple. Computed from
+	// Config at load time so the orchestrator and Reporter agree on the
+	// row label.
 	Identifier string
 }

--- a/internal/batch/target_test.go
+++ b/internal/batch/target_test.go
@@ -1,0 +1,33 @@
+package batch
+
+import (
+	"testing"
+
+	"github.com/koh-sh/apcdeploy/internal/config"
+)
+
+func TestTarget_FieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Region:               "us-east-1",
+		Application:          "my-app",
+		ConfigurationProfile: "my-profile",
+		Environment:          "production",
+	}
+	tgt := &Target{
+		Path:       "./envs/prod.yml",
+		Config:     cfg,
+		Identifier: config.Identifier("", cfg),
+	}
+
+	if got, want := tgt.Identifier, "us-east-1/my-app/my-profile/production"; got != want {
+		t.Errorf("Identifier = %q, want %q", got, want)
+	}
+	if tgt.Config != cfg {
+		t.Errorf("Config pointer not preserved")
+	}
+	if tgt.Path != "./envs/prod.yml" {
+		t.Errorf("Path = %q, want preserved verbatim", tgt.Path)
+	}
+}

--- a/internal/cli/summary.go
+++ b/internal/cli/summary.go
@@ -10,17 +10,21 @@ import (
 //
 //	<verb> [(<elapsed>)] [— v<N>[, <Strategy>][, <addendum>]]
 //
-// elapsed is omitted when start is the zero value, or when verb is "started"
-// (no wait flag was set, so there is no meaningful deploy duration to quote).
+// elapsed is the duration to render. Pass 0 to omit it entirely (used for
+// the "started" verb, which has no wait phase to time). The caller is
+// responsible for choosing the right source of elapsed — wall-clock for
+// --wait-deploy, AWS-reported `CompletedAt - StartedAt` for --wait-bake
+// (so the displayed time isn't inflated by the polling tick lag).
+//
 // addendum is appended after the strategy when non-empty (e.g.
 // "baking started", "deployment #42").
 //
 // Centralised here so run and edit cannot drift — both packages were carrying
 // identical implementations before.
-func FormatDeploymentSummary(verb string, start time.Time, version int32, strategy, addendum string) string {
+func FormatDeploymentSummary(verb string, elapsed time.Duration, version int32, strategy, addendum string) string {
 	out := verb
-	if !start.IsZero() && verb != "started" {
-		out += " (" + FormatElapsed(time.Since(start)) + ")"
+	if elapsed > 0 && verb != "started" {
+		out += " (" + FormatElapsed(elapsed) + ")"
 	}
 	if version > 0 {
 		out += fmt.Sprintf(" — v%d", version)
@@ -38,9 +42,15 @@ func FormatDeploymentSummary(verb string, start time.Time, version int32, strate
 	return out
 }
 
-// FormatElapsed renders a duration as compact "Ns" or "Nm Ns" (or "Nm" when
-// the seconds part is zero). Used by FormatDeploymentSummary; exported so
-// callers that build their own summary strings can stay consistent.
+// FormatElapsed renders a duration as compact "Ns" or "Nm Ns" (or "Nm"
+// when the seconds part is zero). Used by FormatDeploymentSummary and
+// by the multi-config aggregate summary.
+//
+// Sub-second precision is dropped via Round (nearest-second), so the
+// displayed value is the closest integer second to the actual
+// duration — consistent with AppConfig's microsecond-precision
+// timestamps shown in the AWS console / event log. Truncate would
+// always under-report by up to 1s and bias the display.
 func FormatElapsed(d time.Duration) string {
 	d = d.Round(time.Second)
 	if d < time.Minute {

--- a/internal/cli/summary.go
+++ b/internal/cli/summary.go
@@ -6,7 +6,7 @@ import (
 )
 
 // FormatDeploymentSummary builds the post-icon Targets summary line for a
-// run / edit deployment per docs/design/output.md §3.3.2:
+// run / edit deployment:
 //
 //	<verb> [(<elapsed>)] [— v<N>[, <Strategy>][, <addendum>]]
 //

--- a/internal/cli/summary_test.go
+++ b/internal/cli/summary_test.go
@@ -14,12 +14,16 @@ func TestFormatElapsed(t *testing.T) {
 		want string
 	}{
 		{"zero", 0, "0s"},
-		{"sub-second rounds up", 1500 * time.Millisecond, "2s"},
+		{"sub-second rounds up at 0.5s", 1500 * time.Millisecond, "2s"},
+		{"sub-second rounds down below 0.5s", 1499 * time.Millisecond, "1s"},
+		{"under 0.5s rounds to zero", 499 * time.Millisecond, "0s"},
 		{"45s", 45 * time.Second, "45s"},
 		{"59s", 59 * time.Second, "59s"},
 		{"exactly one minute", time.Minute, "1m"},
-		{"1m 1s", 61 * time.Second, "1m 1s"},
-		{"8m 15s", 8*time.Minute + 15*time.Second, "8m 15s"},
+		{"1m 1s preserves seconds", 61 * time.Second, "1m 1s"},
+		{"6m + sub-second jitter rounds nearest", 6*time.Minute + 400*time.Millisecond, "6m"},
+		{"6m + 600ms jitter rounds up to 6m 1s", 6*time.Minute + 600*time.Millisecond, "6m 1s"},
+		{"8m 15s preserves seconds", 8*time.Minute + 15*time.Second, "8m 15s"},
 		{"60m no seconds", 60 * time.Minute, "60m"},
 	}
 	for _, tt := range tests {
@@ -35,14 +39,10 @@ func TestFormatElapsed(t *testing.T) {
 func TestFormatDeploymentSummary(t *testing.T) {
 	t.Parallel()
 
-	// All non-"started" verbs reference the same fixed "8s ago" start so
-	// elapsed is deterministic across cases.
-	fixed := time.Now().Add(-8 * time.Second)
-
 	tests := []struct {
 		name     string
 		verb     string
-		start    time.Time
+		elapsed  time.Duration
 		version  int32
 		strategy string
 		addendum string
@@ -55,17 +55,17 @@ func TestFormatDeploymentSummary(t *testing.T) {
 		},
 		{
 			name: "deployed includes elapsed and addendum",
-			verb: "deployed", start: fixed, version: 42, strategy: "Linear50PercentEvery30Seconds", addendum: "baking started",
+			verb: "deployed", elapsed: 8 * time.Second, version: 42, strategy: "Linear50PercentEvery30Seconds", addendum: "baking started",
 			want: "deployed (8s) — v42, Linear50PercentEvery30Seconds, baking started",
 		},
 		{
 			name: "complete with no addendum",
-			verb: "complete", start: fixed, version: 7, strategy: "Canary10Percent20Minutes",
+			verb: "complete", elapsed: 8 * time.Second, version: 7, strategy: "Canary10Percent20Minutes",
 			want: "complete (8s) — v7, Canary10Percent20Minutes",
 		},
 		{
 			name: "no version inserts strategy after em-dash",
-			verb: "deployed", start: fixed, strategy: "AllAtOnce",
+			verb: "deployed", elapsed: 8 * time.Second, strategy: "AllAtOnce",
 			want: "deployed (8s) — AllAtOnce",
 		},
 		{
@@ -73,11 +73,16 @@ func TestFormatDeploymentSummary(t *testing.T) {
 			verb: "started",
 			want: "started",
 		},
+		{
+			name: "zero elapsed omits the (...) suffix even for non-started verb",
+			verb: "complete", version: 1, strategy: "AllAtOnce",
+			want: "complete — v1, AllAtOnce",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := FormatDeploymentSummary(tt.verb, tt.start, tt.version, tt.strategy, tt.addendum); got != tt.want {
+			if got := FormatDeploymentSummary(tt.verb, tt.elapsed, tt.version, tt.strategy, tt.addendum); got != tt.want {
 				t.Errorf("FormatDeploymentSummary() = %q, want %q", got, tt.want)
 			}
 		})

--- a/internal/cli/targets.go
+++ b/internal/cli/targets.go
@@ -32,7 +32,7 @@ var terminalEscapeRE = regexp.MustCompile(
 
 // sanitizeIdentifier strips ANSI / DEC escape sequences from id. Used at the
 // Targets boundary so caller-supplied identifiers cannot inject terminal
-// control codes (output.md §10.3 — identifier integrity).
+// control codes.
 func sanitizeIdentifier(id string) string {
 	if !strings.ContainsRune(id, '\x1b') {
 		return id
@@ -41,13 +41,13 @@ func sanitizeIdentifier(id string) string {
 }
 
 // targetsBarWidth is the fixed visual width of the deploying-phase progress
-// bar (output.md §5.4). Bars do not adapt to terminal width — they print at
-// 20 cells regardless.
+// bar. Bars do not adapt to terminal width — they print at 20 cells
+// regardless.
 const targetsBarWidth = 20
 
 // targetsIDGap is the minimum gap between the identifier column and the
-// state icon (output.md §5.2). Implementations pad shorter identifiers with
-// spaces so the icon column lines up across rows.
+// state icon. Implementations pad shorter identifiers with spaces so the
+// icon column lines up across rows.
 const targetsIDGap = 3
 
 // targetsRowState captures the lifecycle stage of a single Targets row.

--- a/internal/cli/targets.go
+++ b/internal/cli/targets.go
@@ -110,6 +110,29 @@ func idColumnWidth(ids []string) int {
 	return w + targetsIDGap
 }
 
+// truncateRunes shortens s to at most max runes, appending an ellipsis (…)
+// when truncation actually happens. Returns "" for max <= 0 and "…" for
+// max == 1 — at one rune of budget the ellipsis itself is the only thing
+// that fits.
+//
+// Used by the TTY Targets renderer to keep each row within terminal
+// width: row contents that wrap to a second visual line break the redraw
+// math (\033[NA assumes one terminal line per row), and either accumulate
+// stale fragments or eat earlier rows.
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max == 1 {
+		return "…"
+	}
+	return string(runes[:max-1]) + "…"
+}
+
 // padID returns id padded with spaces to width.
 func padID(id string, width int) string {
 	pad := max(width-visibleWidth(id), 0)

--- a/internal/cli/targets.go
+++ b/internal/cli/targets.go
@@ -110,27 +110,27 @@ func idColumnWidth(ids []string) int {
 	return w + targetsIDGap
 }
 
-// truncateRunes shortens s to at most max runes, appending an ellipsis (…)
-// when truncation actually happens. Returns "" for max <= 0 and "…" for
-// max == 1 — at one rune of budget the ellipsis itself is the only thing
-// that fits.
+// truncateRunes shortens s to at most limit runes, appending an ellipsis
+// (…) when truncation actually happens. Returns "" for limit <= 0 and "…"
+// for limit == 1 — at one rune of budget the ellipsis itself is the only
+// thing that fits.
 //
 // Used by the TTY Targets renderer to keep each row within terminal
 // width: row contents that wrap to a second visual line break the redraw
 // math (\033[NA assumes one terminal line per row), and either accumulate
 // stale fragments or eat earlier rows.
-func truncateRunes(s string, max int) string {
-	if max <= 0 {
+func truncateRunes(s string, limit int) string {
+	if limit <= 0 {
 		return ""
 	}
 	runes := []rune(s)
-	if len(runes) <= max {
+	if len(runes) <= limit {
 		return s
 	}
-	if max == 1 {
+	if limit == 1 {
 		return "…"
 	}
-	return string(runes[:max-1]) + "…"
+	return string(runes[:limit-1]) + "…"
 }
 
 // padID returns id padded with spaces to width.

--- a/internal/cli/targets_plain.go
+++ b/internal/cli/targets_plain.go
@@ -7,9 +7,8 @@ import (
 )
 
 // plainTargets is the non-TTY Targets implementation. Without in-place
-// updates, each phase transition emits a new line in `<id>: <body>` form
-// (output.md §6.2). Progress is decimated to 25/50/75/100% so CI logs
-// stay clean.
+// updates, each phase transition emits a new line in `<id>: <body>` form.
+// Progress is decimated to 25/50/75/100% so CI logs stay clean.
 type plainTargets struct {
 	targetsBase
 	w io.Writer

--- a/internal/cli/targets_plain_test.go
+++ b/internal/cli/targets_plain_test.go
@@ -149,7 +149,7 @@ func TestPlainTargets_EtaIgnoredInSetProgress(t *testing.T) {
 	t.Parallel()
 
 	// SetProgress's eta is intentionally ignored in non-TTY mode (CI logs
-	// stay clean — output.md §6.2 keeps lines to the threshold percent only).
+	// stay clean — lines are kept to the threshold percent only).
 	pt, buf := newTestPlainTargets(t, []string{"id"})
 	defer pt.Close()
 

--- a/internal/cli/targets_test.go
+++ b/internal/cli/targets_test.go
@@ -173,3 +173,32 @@ func TestPadID(t *testing.T) {
 		}
 	}
 }
+
+func TestTruncateRunes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"empty input", "", 10, ""},
+		{"max zero returns empty", "abc", 0, ""},
+		{"max negative returns empty", "abc", -1, ""},
+		{"shorter than max passes through", "abc", 10, "abc"},
+		{"equal to max passes through", "abc", 3, "abc"},
+		{"max one returns ellipsis only", "abc", 1, "…"},
+		{"truncates to max with ellipsis", "abcdef", 4, "abc…"},
+		{"multibyte truncation is rune-aware", "あいうえお", 3, "あい…"},
+		{"long ASCII", strings.Repeat("a", 100), 5, "aaaa…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := truncateRunes(tt.in, tt.max); got != tt.want {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.in, tt.max, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/targets_test.go
+++ b/internal/cli/targets_test.go
@@ -178,26 +178,26 @@ func TestTruncateRunes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		in   string
-		max  int
-		want string
+		name  string
+		in    string
+		limit int
+		want  string
 	}{
 		{"empty input", "", 10, ""},
-		{"max zero returns empty", "abc", 0, ""},
-		{"max negative returns empty", "abc", -1, ""},
-		{"shorter than max passes through", "abc", 10, "abc"},
-		{"equal to max passes through", "abc", 3, "abc"},
-		{"max one returns ellipsis only", "abc", 1, "…"},
-		{"truncates to max with ellipsis", "abcdef", 4, "abc…"},
+		{"limit zero returns empty", "abc", 0, ""},
+		{"limit negative returns empty", "abc", -1, ""},
+		{"shorter than limit passes through", "abc", 10, "abc"},
+		{"equal to limit passes through", "abc", 3, "abc"},
+		{"limit one returns ellipsis only", "abc", 1, "…"},
+		{"truncates to limit with ellipsis", "abcdef", 4, "abc…"},
 		{"multibyte truncation is rune-aware", "あいうえお", 3, "あい…"},
 		{"long ASCII", strings.Repeat("a", 100), 5, "aaaa…"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := truncateRunes(tt.in, tt.max); got != tt.want {
-				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.in, tt.max, got, tt.want)
+			if got := truncateRunes(tt.in, tt.limit); got != tt.want {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.in, tt.limit, got, tt.want)
 			}
 		})
 	}

--- a/internal/cli/targets_tty.go
+++ b/internal/cli/targets_tty.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	bspinner "github.com/charmbracelet/bubbles/spinner"
@@ -13,9 +14,18 @@ import (
 // or animation tick. Pre-printing once and then moving the cursor up by
 // len(rows) for each redraw keeps the cursor math trivial — the same trick
 // ttyChecklist uses.
+//
+// cols is the terminal column width captured at construction; 0 means
+// "unknown — do not truncate". When non-zero, formatLine truncates the
+// row's variable-length payload (errMsg / summary / detail / reason) so
+// each rendered row fits within one terminal line. The redraw assumes
+// one visual line per row (`\033[NA` moves up N logical rows); a wrapped
+// row would shift the cursor and cause earlier output to bleed into
+// subsequent frames.
 type ttyTargets struct {
 	targetsBase
 	w        io.Writer
+	cols     int
 	frames   []string
 	fps      time.Duration
 	frameIdx int
@@ -35,6 +45,7 @@ func newTTYTargets(r *Reporter, ids []string) *ttyTargets {
 	t := &ttyTargets{
 		targetsBase: newTargetsBase(ids),
 		w:           r.errW,
+		cols:        terminalColsOf(r.errW),
 		frames:      bspinner.MiniDot.Frames,
 		fps:         fps,
 		stop:        make(chan struct{}),
@@ -49,6 +60,17 @@ func newTTYTargets(r *Reporter, ids []string) *ttyTargets {
 	return t
 }
 
+// terminalColsOf returns the column width of w when w is an *os.File
+// connected to a TTY; otherwise 0 (used by callers as "do not truncate").
+// Imported into a thin helper rather than inlined so tests can pass an
+// io.Writer (e.g. *bytes.Buffer) without provoking a nil-deref.
+func terminalColsOf(w io.Writer) int {
+	if f, ok := w.(*os.File); ok {
+		return TerminalCols(f)
+	}
+	return 0
+}
+
 // renderInitial prints every row once. After this the cursor sits on the
 // line directly below the last row; subsequent redraws move up by len(order)
 // to reach the top of the block.
@@ -59,16 +81,45 @@ func (t *ttyTargets) renderInitial() {
 }
 
 // redraw rewrites the entire block in place. Caller MUST hold t.mu.
+//
+// `\033[%dA` moves the cursor up by len(order) logical rows. formatLine
+// truncates each row to one terminal line so this stays in sync; on top
+// of that, `\033[J` (clear from cursor to end of screen) runs once after
+// the cursor returns to the top of the block as a safety net for any
+// previous frame that may have overflowed (e.g. a frame written before
+// the terminal width was knowable, or after a SIGWINCH narrowed it).
 func (t *ttyTargets) redraw() {
 	frame := t.frames[t.frameIdx%len(t.frames)]
-	fmt.Fprintf(t.w, "\033[%dA", len(t.order))
+	fmt.Fprintf(t.w, "\033[%dA\r\033[J", len(t.order))
 	for _, id := range t.order {
-		fmt.Fprintf(t.w, "\r\033[K%s\n", t.formatLine(t.rows[id], frame))
+		fmt.Fprintln(t.w, t.formatLine(t.rows[id], frame))
 	}
 }
 
+// formatLine builds one rendered row, truncating long payload fields so
+// the result fits within one terminal line. The fields fed into
+// renderRow are the only variable-length inputs — the icon, "failed: "
+// prefix, and progress bar are fixed-width, so a per-field rune budget
+// is sufficient and avoids ANSI-aware string truncation.
 func (t *ttyTargets) formatLine(row *targetsRow, frame string) string {
-	return padID(row.id, t.idWidth) + renderRow(row, frame)
+	r := *row
+	if t.cols > 0 {
+		// Reserve fixed budget for: identifier column, gap, state icon,
+		// space, common prefixes ("failed: " etc.), and a 1-col safety
+		// margin so the cursor never sits exactly at the right edge
+		// (some terminals wrap on column-0 of the next line in that
+		// case). Floor at 10 so very narrow terminals still get
+		// something visible rather than a string of just ellipses.
+		budget := t.cols - t.idWidth - 12
+		if budget < 10 {
+			budget = 10
+		}
+		r.errMsg = truncateRunes(r.errMsg, budget)
+		r.summary = truncateRunes(r.summary, budget)
+		r.detail = truncateRunes(r.detail, budget)
+		r.reason = truncateRunes(r.reason, budget)
+	}
+	return padID(r.id, t.idWidth) + renderRow(&r, frame)
 }
 
 func (t *ttyTargets) animate() {

--- a/internal/cli/targets_tty.go
+++ b/internal/cli/targets_tty.go
@@ -110,10 +110,7 @@ func (t *ttyTargets) formatLine(row *targetsRow, frame string) string {
 		// (some terminals wrap on column-0 of the next line in that
 		// case). Floor at 10 so very narrow terminals still get
 		// something visible rather than a string of just ellipses.
-		budget := t.cols - t.idWidth - 12
-		if budget < 10 {
-			budget = 10
-		}
+		budget := max(t.cols-t.idWidth-12, 10)
 		r.errMsg = truncateRunes(r.errMsg, budget)
 		r.summary = truncateRunes(r.summary, budget)
 		r.detail = truncateRunes(r.detail, budget)

--- a/internal/cli/targets_tty_test.go
+++ b/internal/cli/targets_tty_test.go
@@ -140,7 +140,7 @@ func TestTTYTargets_TruncatesLongFields(t *testing.T) {
 	// trailing "\n" is not counted). The output may contain ANSI
 	// movement sequences but stripANSI removes them, leaving only
 	// the payload lines.
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if n := len([]rune(line)); n > tt.cols {
 			t.Errorf("line of %d runes exceeds cols=%d:\n%q", n, tt.cols, line)
 		}

--- a/internal/cli/targets_tty_test.go
+++ b/internal/cli/targets_tty_test.go
@@ -116,3 +116,36 @@ func TestTTYTargets_UnknownIDIgnored(t *testing.T) {
 	// no panics, no row state for "missing"
 	tt.Close()
 }
+
+// TestTTYTargets_TruncatesLongFields verifies that when cols is set,
+// long error/summary/detail/reason payloads are truncated so the
+// rendered row fits within the terminal width. Without this guard the
+// `\033[NA` redraw math drifts (one logical row = two visual lines)
+// and earlier rows accumulate in subsequent frames — see the
+// CreateHostedConfigurationVersion ConflictException reproducer.
+func TestTTYTargets_TruncatesLongFields(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	r := &Reporter{outW: &bytes.Buffer{}, errW: buf, outTTY: false, errTTY: true}
+	tt := newTTYTargets(r, []string{"id"})
+	tt.cols = 60 // pretend the terminal is 60 cols wide
+
+	long := strings.Repeat("x", 200)
+	tt.Fail("id", errors.New(long))
+	tt.Close()
+
+	out := stripANSI(buf.String())
+	// Each line printed by ttyTargets must be ≤ cols runes (the
+	// trailing "\n" is not counted). The output may contain ANSI
+	// movement sequences but stripANSI removes them, leaving only
+	// the payload lines.
+	for _, line := range strings.Split(out, "\n") {
+		if n := len([]rune(line)); n > tt.cols {
+			t.Errorf("line of %d runes exceeds cols=%d:\n%q", n, tt.cols, line)
+		}
+	}
+	if !strings.Contains(out, "…") {
+		t.Errorf("expected ellipsis in truncated output, got:\n%s", out)
+	}
+}

--- a/internal/cli/tty.go
+++ b/internal/cli/tty.go
@@ -14,3 +14,17 @@ func IsTerminal(f *os.File) bool {
 	}
 	return term.IsTerminal(int(f.Fd()))
 }
+
+// TerminalCols returns the column width of f when it is a TTY, or 0 when
+// the size cannot be determined (non-TTY, closed file, syscall error).
+// Callers MUST treat 0 as "unknown — do not truncate".
+func TerminalCols(f *os.File) int {
+	if f == nil {
+		return 0
+	}
+	w, _, err := term.GetSize(int(f.Fd()))
+	if err != nil {
+		return 0
+	}
+	return w
+}

--- a/internal/cli/tty_test.go
+++ b/internal/cli/tty_test.go
@@ -38,11 +38,9 @@ func TestTerminalColsOf(t *testing.T) {
 	t.Parallel()
 
 	// terminalColsOf accepts io.Writer; a non-*os.File path returns 0.
-	type stubWriter struct{}
 	if got := terminalColsOf(stubWriterImpl{}); got != 0 {
 		t.Errorf("terminalColsOf(non-file) = %d, want 0", got)
 	}
-	_ = stubWriter{}
 }
 
 type stubWriterImpl struct{}

--- a/internal/cli/tty_test.go
+++ b/internal/cli/tty_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+// TestTerminalCols covers the boundaries that the Targets renderer
+// relies on for its truncation guard: a nil file and a non-TTY file
+// must both return 0 ("unknown — do not truncate") rather than panic.
+// The TTY-positive branch needs a real PTY which the unit-test sandbox
+// doesn't provide; that path is exercised in practice via the e2e
+// run command and validated by TestTTYTargets_TruncatesLongFields with
+// an injected cols value.
+func TestTerminalCols(t *testing.T) {
+	t.Parallel()
+
+	if got := TerminalCols(nil); got != 0 {
+		t.Errorf("TerminalCols(nil) = %d, want 0", got)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close(); _ = w.Close() })
+
+	if got := TerminalCols(r); got != 0 {
+		t.Errorf("TerminalCols(non-TTY pipe) = %d, want 0", got)
+	}
+}
+
+// TestTerminalColsOf covers the io.Writer wrapper used by ttyTargets:
+// a *bytes.Buffer (and any non-*os.File) must return 0 so tests that
+// inject a buffer don't accidentally enable truncation based on a
+// stale cols value.
+func TestTerminalColsOf(t *testing.T) {
+	t.Parallel()
+
+	// terminalColsOf accepts io.Writer; a non-*os.File path returns 0.
+	type stubWriter struct{}
+	if got := terminalColsOf(stubWriterImpl{}); got != 0 {
+		t.Errorf("terminalColsOf(non-file) = %d, want 0", got)
+	}
+	_ = stubWriter{}
+}
+
+type stubWriterImpl struct{}
+
+func (stubWriterImpl) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/config/identifier.go
+++ b/internal/config/identifier.go
@@ -3,11 +3,10 @@ package config
 // Identifier returns the canonical "region/app/profile/env" string used
 // throughout the CLI to label a single deployment target.
 //
-// The 4-tuple is the contract for target identity (see
-// docs/design/multi-config.md F-06). The same function is used by the
-// Targets reporter primitive and by the multi-config orchestrator so that
-// the identifier shown in logs matches the identifier used for duplicate
-// detection.
+// The 4-tuple is the contract for target identity. The same function is
+// used by the Targets reporter primitive and by the multi-config
+// orchestrator so that the identifier shown in logs matches the
+// identifier used for duplicate detection.
 //
 // region argument is used when cfg.Region is empty (e.g. resolved later
 // from the AWS SDK default chain). When cfg.Region is set it always wins.

--- a/internal/diff/display.go
+++ b/internal/diff/display.go
@@ -21,8 +21,7 @@ var inProgressWarningSink io.Writer = os.Stderr
 // still rolling out.
 //
 // For N=1 (single -c) callers, the unified diff body is emitted without a
-// `=== <id> ===` header so it can be piped straight into patch/git apply
-// (output.md §7.2 stdout header rules).
+// `=== <id> ===` header so it can be piped straight into patch/git apply.
 func display(r reporter.Reporter, tg reporter.Targets, id string, result *Result, deployment *aws.DeploymentInfo) {
 	if !result.HasChanges {
 		tg.Done(id, "no changes")
@@ -37,9 +36,9 @@ func display(r reporter.Reporter, tg reporter.Targets, id string, result *Result
 }
 
 // formatDiffSummary renders the post-icon Targets summary for a diff with
-// changes. The wording matches output.md §7.2 (a) — "diff (N lines changed)"
-// — but augments it with the +/- breakdown so users get the deletion/addition
-// split without scrolling through the patch.
+// changes. The wording is "diff (N lines changed)" augmented with the
+// +/- breakdown so users get the deletion/addition split without
+// scrolling through the patch.
 func formatDiffSummary(added, removed int) string {
 	total := added + removed
 	noun := "lines"

--- a/internal/diff/executor.go
+++ b/internal/diff/executor.go
@@ -39,8 +39,8 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 
 // Execute performs the diff workflow for a single config file. Stdout
 // emission (the unified diff body) happens inline so the single-target
-// output matches the existing single-config behaviour: no
-// `=== <id> ===` header (output.md §7.2 stdout header rules).
+// output matches the existing single-config behaviour: no `=== <id> ===`
+// header.
 //
 // The multi-config path uses RunOnTarget instead and is responsible for
 // buffering and reordering the diff bodies; see cmd/diff.go.
@@ -93,8 +93,8 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 //
 // The orchestrator path in cmd/diff.go collects payloads per target
 // and flushes them to Reporter.Diff in argument order with a
-// `=== <id> ===` header (output.md §7.2). The single-target Execute
-// emits payload directly without a header.
+// `=== <id> ===` header. The single-target Execute emits payload
+// directly without a header.
 func (e *Executor) RunOnTarget(ctx context.Context, t *batch.Target, tr reporter.TargetReporter) ([]byte, bool, error) {
 	awsClient, err := e.clientFactory(ctx, t.Config.Region)
 	if err != nil {

--- a/internal/diff/executor.go
+++ b/internal/diff/executor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/koh-sh/apcdeploy/internal/aws"
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/config"
 	"github.com/koh-sh/apcdeploy/internal/reporter"
 )
@@ -36,19 +37,13 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 	}
 }
 
-// Execute performs the complete diff workflow.
+// Execute performs the diff workflow for a single config file. Stdout
+// emission (the unified diff body) happens inline so the single-target
+// output matches the existing single-config behaviour: no
+// `=== <id> ===` header (output.md §7.2 stdout header rules).
 //
-// Output shape (docs/design/output.md §7.2):
-//   - changed:       ✓ diff (N lines changed) on the Targets row, unified diff
-//     on stdout (no `=== ===` header for N=1, per §7.2 stdout
-//     header rules).
-//   - no changes:    ✓ no changes on the Targets row, no stdout payload.
-//   - no deployment: ✓ no prior deployment on the Targets row, local data on
-//     stdout (acts as the right-hand side of the would-be diff).
-//   - errors:        ✗ failed: <message> on the Targets row.
-//
-// The in-progress deployment warning still bypasses the Reporter via display
-// (CONTRACT EXCEPTION) so scripts under --silent still see the risk note.
+// The multi-config path uses RunOnTarget instead and is responsible for
+// buffering and reordering the diff bodies; see cmd/diff.go.
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 	cfg, err := config.LoadConfig(opts.ConfigFile)
 	if err != nil {
@@ -60,57 +55,129 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("failed to initialize AWS client: %w", err)
 	}
 
-	localData, err := config.LoadDataFile(cfg.DataFile)
-	if err != nil {
-		return fmt.Errorf("failed to load local configuration file: %w", err)
+	target := &batch.Target{
+		Path:       opts.ConfigFile,
+		Config:     cfg,
+		Identifier: config.Identifier(awsClient.Region, cfg),
 	}
 
-	id := config.Identifier(awsClient.Region, cfg)
-	tg := e.reporter.Targets([]string{id})
+	tg := e.reporter.Targets([]string{target.Identifier})
 	defer tg.Close()
-	tg.SetPhase(id, "comparing", "")
+	tr := batch.NewTargetReporter(tg, target.Identifier)
+
+	payload, hasChanges, isPriorMissing, err := e.runOnTargetWithClient(ctx, target, tr, awsClient)
+	if err != nil {
+		return err
+	}
+	// Preserve the existing single-target stdout split: when there is no
+	// prior deployment, the local data is raw user content (use Data) so
+	// it can be piped into apcdeploy run / git apply unchanged. Real
+	// diff bodies go through Diff so the colorizer can apply +/-
+	// styling. The multi-target path always uses Diff (one stream).
+	if len(payload) > 0 {
+		if isPriorMissing {
+			e.reporter.Data(payload)
+		} else {
+			e.reporter.Diff(payload)
+		}
+	}
+	if opts.ExitNonzero && hasChanges {
+		return ErrDiffFound
+	}
+	return nil
+}
+
+// RunOnTarget runs diff for one pre-loaded target. It returns the
+// stdout payload (nil when there are no changes), a hasChanges flag
+// (used by --exit-nonzero), and the error.
+//
+// The orchestrator path in cmd/diff.go collects payloads per target
+// and flushes them to Reporter.Diff in argument order with a
+// `=== <id> ===` header (output.md §7.2). The single-target Execute
+// emits payload directly without a header.
+func (e *Executor) RunOnTarget(ctx context.Context, t *batch.Target, tr reporter.TargetReporter) ([]byte, bool, error) {
+	awsClient, err := e.clientFactory(ctx, t.Config.Region)
+	if err != nil {
+		tr.Fail(err)
+		return nil, false, fmt.Errorf("failed to initialize AWS client: %w", err)
+	}
+	payload, hasChanges, _, err := e.runOnTargetWithClient(ctx, t, tr, awsClient)
+	return payload, hasChanges, err
+}
+
+// runOnTargetWithClient is the per-target body shared by Execute and
+// RunOnTarget. The in-progress deployment warning bypasses the Reporter
+// (CONTRACT EXCEPTION in display.go); the diff payload is returned
+// rather than emitted so the caller can order multi-target output.
+//
+// The third return is "isPriorMissing" — true when the row reported
+// "no prior deployment" so Execute can route the payload through Data
+// instead of Diff (raw local content is not a unified diff).
+func (e *Executor) runOnTargetWithClient(ctx context.Context, t *batch.Target, tr reporter.TargetReporter, awsClient *aws.Client) ([]byte, bool, bool, error) {
+	cfg := t.Config
+
+	tr.SetPhase("comparing", "")
 
 	resolver := aws.NewResolver(awsClient)
 	resources, err := resolver.ResolveAll(ctx, cfg.Application, cfg.ConfigurationProfile, cfg.Environment, cfg.DeploymentStrategy)
 	if err != nil {
-		tg.Fail(id, err)
-		return fmt.Errorf("failed to resolve resources: %w", err)
+		tr.Fail(err)
+		return nil, false, false, fmt.Errorf("failed to resolve resources: %w", err)
 	}
 
 	deployment, err := aws.GetLatestDeployment(ctx, awsClient, resources.ApplicationID, resources.EnvironmentID, resources.Profile.ID)
 	if err != nil {
-		tg.Fail(id, err)
-		return fmt.Errorf("failed to get latest deployment: %w", err)
+		tr.Fail(err)
+		return nil, false, false, fmt.Errorf("failed to get latest deployment: %w", err)
+	}
+
+	localData, err := config.LoadDataFile(cfg.DataFile)
+	if err != nil {
+		tr.Fail(err)
+		return nil, false, false, fmt.Errorf("failed to load local configuration file: %w", err)
 	}
 
 	if deployment == nil {
-		tg.Done(id, "no prior deployment")
-		// The local data is the would-be initial deployment payload — emit it
-		// to stdout so consumers can pipe it into apcdeploy run / git apply.
-		e.reporter.Data(localData)
-		if len(localData) > 0 && localData[len(localData)-1] != '\n' {
-			e.reporter.Data([]byte("\n"))
-		}
-		return nil
+		tr.Done("no prior deployment")
+		// Local data is the would-be initial deployment payload. Hand
+		// it back as the stdout payload — Execute will route it
+		// through Data so it stays raw / pipeable.
+		return ensureTrailingNewlineBytes(localData), true, true, nil
 	}
 
 	remoteData, err := aws.GetHostedConfigurationVersion(ctx, awsClient, resources.ApplicationID, resources.Profile.ID, deployment.ConfigurationVersion)
 	if err != nil {
-		tg.Fail(id, err)
-		return fmt.Errorf("failed to get deployed configuration: %w", err)
+		tr.Fail(err)
+		return nil, false, false, fmt.Errorf("failed to get deployed configuration: %w", err)
 	}
 
 	diffResult, err := calculate(string(remoteData), string(localData), cfg.DataFile, resources.Profile.Type)
 	if err != nil {
-		tg.Fail(id, err)
-		return fmt.Errorf("failed to calculate diff: %w", err)
+		tr.Fail(err)
+		return nil, false, false, fmt.Errorf("failed to calculate diff: %w", err)
 	}
 
-	display(e.reporter, tg, id, diffResult, deployment)
-
-	if opts.ExitNonzero && diffResult.HasChanges {
-		return ErrDiffFound
+	if !diffResult.HasChanges {
+		tr.Done("no changes")
+		displayDeploymentWarning(deployment)
+		return nil, false, false, nil
 	}
 
-	return nil
+	added, removed := countChanges(diffResult.UnifiedDiff)
+	tr.Done(formatDiffSummary(added, removed))
+	displayDeploymentWarning(deployment)
+	return []byte(ensureTrailingNewline(diffResult.UnifiedDiff)), true, false, nil
+}
+
+// ensureTrailingNewlineBytes is the []byte version of ensureTrailingNewline,
+// used for the "no prior deployment" payload (which is raw user data, not a
+// unified diff string).
+func ensureTrailingNewlineBytes(b []byte) []byte {
+	if len(b) == 0 || b[len(b)-1] == '\n' {
+		return b
+	}
+	out := make([]byte, len(b)+1)
+	copy(out, b)
+	out[len(b)] = '\n'
+	return out
 }

--- a/internal/diff/run_on_target_test.go
+++ b/internal/diff/run_on_target_test.go
@@ -1,0 +1,58 @@
+package diff
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	awsInternal "github.com/koh-sh/apcdeploy/internal/aws"
+	"github.com/koh-sh/apcdeploy/internal/batch"
+	"github.com/koh-sh/apcdeploy/internal/config"
+	reportertest "github.com/koh-sh/apcdeploy/internal/reporter/testing"
+)
+
+// TestRunOnTarget_ClientFactoryError covers the early-return path of
+// RunOnTarget when the AWS client factory itself fails. The TargetReporter
+// must be moved to Fail before the helper returns, so the orchestrator's
+// row never stays in "running".
+func TestRunOnTarget_ClientFactoryError(t *testing.T) {
+	t.Parallel()
+
+	failure := errors.New("creds boom")
+	factory := func(ctx context.Context, region string) (*awsInternal.Client, error) {
+		return nil, failure
+	}
+
+	rep := &reportertest.MockReporter{}
+	executor := NewExecutorWithFactory(rep, factory)
+
+	target := &batch.Target{
+		Path: "test.yml",
+		Config: &config.Config{
+			Region:               "us-east-1",
+			Application:          "app",
+			ConfigurationProfile: "profile",
+			Environment:          "env",
+			DataFile:             "/tmp/does-not-matter",
+		},
+		Identifier: "us-east-1/app/profile/env",
+	}
+
+	tg := rep.Targets([]string{target.Identifier})
+	defer tg.Close()
+	tr := batch.NewTargetReporter(tg, target.Identifier)
+
+	payload, hasChanges, err := executor.RunOnTarget(context.Background(), target, tr)
+	if err == nil {
+		t.Fatal("expected error from RunOnTarget when clientFactory fails")
+	}
+	if !errors.Is(err, failure) {
+		t.Errorf("err = %v, want wrapping %v", err, failure)
+	}
+	if payload != nil {
+		t.Errorf("payload = %q, want nil on factory failure", payload)
+	}
+	if hasChanges {
+		t.Errorf("hasChanges = true, want false on factory failure")
+	}
+}

--- a/internal/display/status.go
+++ b/internal/display/status.go
@@ -30,8 +30,8 @@ func DeploymentStatus(r reporter.Reporter, deployment *aws.DeploymentDetails, cf
 		{"Profile", resources.Profile.Name},
 		{"Environment", cfg.Environment},
 		// "Deployment Number" and "Hosted Config Version" use distinct labels
-		// (output.md §3.3.1 / §7.4) to make the scope explicit: deployment
-		// numbers are environment-scoped while hosted-config versions are
+		// to make the scope explicit: deployment numbers are
+		// environment-scoped while hosted-config versions are
 		// configuration-profile-scoped, and the two values can diverge.
 		{"Deployment Number", strconv.Itoa(int(deployment.DeploymentNumber))},
 		{"Status", cli.StateBadge(string(deployment.State))},

--- a/internal/edit/workflow.go
+++ b/internal/edit/workflow.go
@@ -274,7 +274,7 @@ func (w *workflow) waitIfRequested(ctx context.Context, tg reporter.Targets, id 
 			tg.Fail(id, err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}
-		tg.Done(id, cli.FormatDeploymentSummary("deployed", deployStart, versionNumber, strategyName, "baking started"))
+		tg.Done(id, cli.FormatDeploymentSummary("deployed", awsDeployElapsed(ctx, w.awsClient, t.AppID, t.EnvID, deploymentNumber, deployStart), versionNumber, strategyName, "baking started"))
 	case opts.WaitBake:
 		// waitCtx caps total wait at opts.Timeout. The per-phase timeout
 		// passed below is the remaining budget against that deadline so the
@@ -292,11 +292,36 @@ func (w *workflow) waitIfRequested(ctx context.Context, tg reporter.Targets, id 
 			tg.Fail(id, err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}
-		tg.Done(id, cli.FormatDeploymentSummary("complete", deployStart, versionNumber, strategyName, ""))
+		tg.Done(id, cli.FormatDeploymentSummary("complete", awsBakeElapsed(ctx, w.awsClient, t.AppID, t.EnvID, deploymentNumber, deployStart), versionNumber, strategyName, ""))
 	default:
-		tg.Done(id, cli.FormatDeploymentSummary("started", deployStart, versionNumber, strategyName, fmt.Sprintf("deployment #%d", deploymentNumber)))
+		tg.Done(id, cli.FormatDeploymentSummary("started", 0, versionNumber, strategyName, fmt.Sprintf("deployment #%d", deploymentNumber)))
 	}
 	return nil
+}
+
+// awsDeployElapsed mirrors run.Deployer.AWSElapsedForDeploy for the
+// edit workflow (which doesn't carry a Deployer). Returns
+// BAKE_TIME_STARTED.OccurredAt - StartedAt when both are available;
+// falls back to wall-clock otherwise.
+func awsDeployElapsed(ctx context.Context, client *awsInternal.Client, appID, envID string, deploymentNumber int32, fallback time.Time) time.Duration {
+	details, err := awsInternal.GetDeploymentDetails(ctx, client, appID, envID, deploymentNumber)
+	if err == nil && details.StartedAt != nil {
+		if bakeStart := awsInternal.BakeTimeStartedAt(details); bakeStart != nil {
+			return bakeStart.Sub(*details.StartedAt)
+		}
+	}
+	return time.Since(fallback)
+}
+
+// awsBakeElapsed mirrors run.Deployer.AWSElapsedForBake. Returns
+// CompletedAt - StartedAt when both are available; falls back to
+// wall-clock otherwise.
+func awsBakeElapsed(ctx context.Context, client *awsInternal.Client, appID, envID string, deploymentNumber int32, fallback time.Time) time.Duration {
+	details, err := awsInternal.GetDeploymentDetails(ctx, client, appID, envID, deploymentNumber)
+	if err == nil && details.StartedAt != nil && details.CompletedAt != nil {
+		return details.CompletedAt.Sub(*details.StartedAt)
+	}
+	return time.Since(fallback)
 }
 
 // remainingDuration returns the time until deadline, clamped at 1s to

--- a/internal/edit/workflow.go
+++ b/internal/edit/workflow.go
@@ -83,9 +83,9 @@ func (t *resolvedTargets) Identifier(region string) string {
 
 // Run executes the edit workflow.
 //
-// Output shape (docs/design/output.md §7.6):
+// Output shape:
 //   - resolve / fetch / ongoing-check are silent unless they fail
-//   - $EDITOR launches without a "launching $EDITOR" spinner (§7.6)
+//   - $EDITOR launches without a "launching $EDITOR" spinner
 //   - after the editor closes, a single Targets row carries the deployment
 //     lifecycle: creating-version → deploying → ✓ deployed/complete (...)
 //     or ⊘ skipped (no changes) when the edit was a no-op.
@@ -185,9 +185,9 @@ func (w *workflow) prepareDeployment(ctx context.Context, t *resolvedTargets, op
 func (w *workflow) editAndDeploy(ctx context.Context, t *resolvedTargets, deployed *awsInternal.DeployedConfigInfo, strategyID, strategyName string, opts *Options) error {
 	ext := config.ExtensionForContentType(deployed.ContentType)
 
-	// No "launching $EDITOR" spinner per output.md §7.6 — short-lived
-	// spinners on instant operations create flicker, and the editor itself
-	// is the user-facing signal that a hand-off is happening.
+	// No "launching $EDITOR" spinner — short-lived spinners on instant
+	// operations create flicker, and the editor itself is the user-facing
+	// signal that a hand-off is happening.
 	_, edited, err := editBuffer(deployed.Content, ext)
 	if err != nil {
 		return fmt.Errorf("failed to edit configuration: %w", err)
@@ -263,8 +263,7 @@ func resolveStrategy(ctx context.Context, resolver *awsInternal.Resolver, provid
 
 // waitIfRequested optionally blocks for the deploy or bake phase to complete,
 // driving the same Targets row through the deploying/baking sub-phases that
-// run uses. The done summary follows the output.md §3.3.2 format and
-// distinguishes the verb by wait mode (output.md §7.1.0).
+// run uses. The done summary distinguishes the verb by wait mode.
 func (w *workflow) waitIfRequested(ctx context.Context, tg reporter.Targets, id string, t *resolvedTargets, deploymentNumber, versionNumber int32, strategyName string, deployStart time.Time, opts *Options) error {
 	timeout := time.Duration(opts.Timeout) * time.Second
 	tr := batch.NewTargetReporter(tg, id)

--- a/internal/edit/workflow.go
+++ b/internal/edit/workflow.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	awsInternal "github.com/koh-sh/apcdeploy/internal/aws"
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/cli"
 	"github.com/koh-sh/apcdeploy/internal/config"
 	initPkg "github.com/koh-sh/apcdeploy/internal/init"
@@ -266,9 +267,10 @@ func resolveStrategy(ctx context.Context, resolver *awsInternal.Resolver, provid
 // distinguishes the verb by wait mode (output.md §7.1.0).
 func (w *workflow) waitIfRequested(ctx context.Context, tg reporter.Targets, id string, t *resolvedTargets, deploymentNumber, versionNumber int32, strategyName string, deployStart time.Time, opts *Options) error {
 	timeout := time.Duration(opts.Timeout) * time.Second
+	tr := batch.NewTargetReporter(tg, id)
 	switch {
 	case opts.WaitDeploy:
-		if err := w.awsClient.WaitForDeploymentPhase(ctx, t.AppID, t.EnvID, deploymentNumber, false, timeout, run.MakeTargetsDeployTick(tg, id)); err != nil {
+		if err := w.awsClient.WaitForDeploymentPhase(ctx, t.AppID, t.EnvID, deploymentNumber, false, timeout, run.MakeTargetsDeployTick(tr)); err != nil {
 			tg.Fail(id, err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}
@@ -281,12 +283,12 @@ func (w *workflow) waitIfRequested(ctx context.Context, tg reporter.Targets, id 
 		waitCtx, cancel := context.WithDeadline(ctx, deadline)
 		defer cancel()
 
-		if err := w.awsClient.WaitForDeploymentPhase(waitCtx, t.AppID, t.EnvID, deploymentNumber, false, remainingDuration(deadline), run.MakeTargetsDeployTick(tg, id)); err != nil {
+		if err := w.awsClient.WaitForDeploymentPhase(waitCtx, t.AppID, t.EnvID, deploymentNumber, false, remainingDuration(deadline), run.MakeTargetsDeployTick(tr)); err != nil {
 			tg.Fail(id, err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}
 		tg.SetPhase(id, "baking", "")
-		if err := w.awsClient.WaitForBakingComplete(waitCtx, t.AppID, t.EnvID, deploymentNumber, remainingDuration(deadline), run.MakeTargetsBakeTick(tg, id)); err != nil {
+		if err := w.awsClient.WaitForBakingComplete(waitCtx, t.AppID, t.EnvID, deploymentNumber, remainingDuration(deadline), run.MakeTargetsBakeTick(tr)); err != nil {
 			tg.Fail(id, err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}

--- a/internal/errors/resolution.go
+++ b/internal/errors/resolution.go
@@ -2,8 +2,8 @@
 // hints rendered in the Errors: section of CLI output.
 //
 // The map is intentionally minimal: only the most frequent failure codes are
-// covered (see docs/design/output.md §8.3). New entries are added on demand
-// when a real failure shows up — no speculative hints.
+// covered. New entries are added on demand when a real failure shows up —
+// no speculative hints.
 package errors
 
 import (
@@ -26,7 +26,7 @@ var resolutionHints = map[string]string{
 // known set.
 //
 // Callers print "Resolution: <hint>" only when the returned string is
-// non-empty (do not invent hints for unknown codes — see output.md §8.3).
+// non-empty.
 func Resolution(err error) string {
 	if err == nil {
 		return ""

--- a/internal/get/executor.go
+++ b/internal/get/executor.go
@@ -42,18 +42,18 @@ func NewExecutorWithFactory(rep reporter.Reporter, prom prompt.Prompter, factory
 
 // Execute performs the complete configuration retrieval workflow.
 //
-// Output shape (docs/design/output.md §7.5):
+// Output shape:
 //   - interactive: identifier shown as Header, cost notice via Warn, prompt;
 //     the configuration body lands on stdout after the user accepts.
 //   - --yes (TTY): a single Targets row finalised as ✓ fetched, plus the
 //     configuration body on stdout.
 //   - --silent --yes: stdout-only — the user has explicitly opted out of
-//     stderr noise (output.md §7.5 (c)).
+//     stderr noise.
 //
 // Resource resolution happens before the cost prompt because List APIs do
 // not incur per-call charges and it gives the user a clearer error path
-// when names don't match (output.md §7.5 (a) shows the prompt first, but
-// the resolve step is invisible to the user when it succeeds).
+// when names don't match (the resolve step is invisible to the user when
+// it succeeds).
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 	cfg, err := config.LoadConfig(opts.ConfigFile)
 	if err != nil {
@@ -91,8 +91,8 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 
 		// Fetch silently after acceptance: the user already sees the
 		// identifier in the Header above; an extra Targets row would just
-		// duplicate it (output.md §7.5 (a) — the body lands on stdout with
-		// no completion line on stderr).
+		// duplicate it — the body lands on stdout with no completion line
+		// on stderr.
 		configData, err := getter.GetConfiguration(ctx, resolved)
 		if err != nil {
 			return fmt.Errorf("failed to get configuration for profile %q in environment %q: %w",

--- a/internal/pull/executor.go
+++ b/internal/pull/executor.go
@@ -38,7 +38,7 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 // per-target body is shared with the multi-config orchestrator path
 // (RunOnTarget) so both routes produce identical Targets output.
 //
-// Output shape (docs/design/output.md §7.3):
+// Output shape:
 //   - updated:        ✓ updated <data-file-path>
 //   - no changes:     ✓ no changes
 //   - no deployment:  ✗ failed: no deployment found  (returns aws.ErrNoDeployment)
@@ -51,7 +51,7 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 
 	// Resolve the AWS client first so the row identifier reflects the
 	// SDK-default region when cfg.Region was omitted (multi-config users
-	// are expected to set region in yml — see multi-config.md §6.2).
+	// are expected to set region in yml).
 	awsClient, err := e.clientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS client: %w", err)

--- a/internal/pull/executor.go
+++ b/internal/pull/executor.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/koh-sh/apcdeploy/internal/aws"
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/config"
 	"github.com/koh-sh/apcdeploy/internal/reporter"
 )
@@ -33,7 +34,9 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 	}
 }
 
-// Execute performs the complete pull workflow.
+// Execute performs the pull workflow for a single config file. The
+// per-target body is shared with the multi-config orchestrator path
+// (RunOnTarget) so both routes produce identical Targets output.
 //
 // Output shape (docs/design/output.md §7.3):
 //   - updated:        ✓ updated <data-file-path>
@@ -46,37 +49,67 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
+	// Resolve the AWS client first so the row identifier reflects the
+	// SDK-default region when cfg.Region was omitted (multi-config users
+	// are expected to set region in yml — see multi-config.md §6.2).
 	awsClient, err := e.clientFactory(ctx, cfg.Region)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS client: %w", err)
 	}
 
-	id := config.Identifier(awsClient.Region, cfg)
-	tg := e.reporter.Targets([]string{id})
+	target := &batch.Target{
+		Path:       opts.ConfigFile,
+		Config:     cfg,
+		Identifier: config.Identifier(awsClient.Region, cfg),
+	}
+
+	tg := e.reporter.Targets([]string{target.Identifier})
 	defer tg.Close()
-	tg.SetPhase(id, "fetching", "")
+	tr := batch.NewTargetReporter(tg, target.Identifier)
+
+	return e.runOnTargetWithClient(ctx, target, tr, awsClient)
+}
+
+// RunOnTarget runs the pull workflow for one pre-loaded target. Used by
+// the multi-config orchestrator (cmd/pull.go wires it as the
+// batch.ExecuteFunc); callers MUST drive the returned TargetReporter to
+// a terminal state via tr.Done / tr.Skip / tr.Fail (this function does).
+func (e *Executor) RunOnTarget(ctx context.Context, t *batch.Target, tr reporter.TargetReporter) error {
+	awsClient, err := e.clientFactory(ctx, t.Config.Region)
+	if err != nil {
+		tr.Fail(err)
+		return fmt.Errorf("failed to initialize AWS client: %w", err)
+	}
+	return e.runOnTargetWithClient(ctx, t, tr, awsClient)
+}
+
+// runOnTargetWithClient is the per-target body shared by Execute (single
+// config) and RunOnTarget (orchestrator). t.Config.DataFile is already
+// resolved to an absolute path by config.LoadConfig, so no relative-path
+// fix-up is needed here.
+func (e *Executor) runOnTargetWithClient(ctx context.Context, t *batch.Target, tr reporter.TargetReporter, awsClient *aws.Client) error {
+	cfg := t.Config
+
+	tr.SetPhase("fetching", "")
 
 	resolver := aws.NewResolver(awsClient)
 	resources, err := resolver.ResolveAll(ctx, cfg.Application, cfg.ConfigurationProfile, cfg.Environment, "")
 	if err != nil {
-		tg.Fail(id, err)
+		tr.Fail(err)
 		return fmt.Errorf("failed to resolve resources: %w", err)
 	}
 
 	deployedConfig, err := aws.GetLatestDeployedConfiguration(ctx, awsClient, resources.ApplicationID, resources.EnvironmentID, resources.Profile.ID)
 	if err != nil {
-		tg.Fail(id, err)
+		tr.Fail(err)
 		return fmt.Errorf("failed to get latest deployed configuration: %w", err)
 	}
 	if deployedConfig == nil {
-		tg.Fail(id, aws.ErrNoDeployment)
+		tr.Fail(aws.ErrNoDeployment)
 		return fmt.Errorf("%w: run 'apcdeploy run' to create the first deployment", aws.ErrNoDeployment)
 	}
 
 	dataFilePath := cfg.DataFile
-	if !filepath.IsAbs(dataFilePath) {
-		dataFilePath = filepath.Join(filepath.Dir(opts.ConfigFile), cfg.DataFile)
-	}
 
 	// Compare against the existing local file (if any) so a no-op pull skips
 	// the write — pull is idempotent and should not touch mtimes when nothing
@@ -86,19 +119,19 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 		ext := filepath.Ext(dataFilePath)
 		hasChanges, err := config.HasContentChanged(localData, deployedConfig.Content, ext, resources.Profile.Type)
 		if err != nil {
-			tg.Fail(id, err)
+			tr.Fail(err)
 			return fmt.Errorf("failed to check for changes: %w", err)
 		}
 		if !hasChanges {
-			tg.Done(id, "no changes")
+			tr.Done("no changes")
 			return nil
 		}
 	}
 
 	if err := config.WriteDataFile(deployedConfig.Content, deployedConfig.ContentType, dataFilePath, resources.Profile.Type, true); err != nil {
-		tg.Fail(id, err)
+		tr.Fail(err)
 		return fmt.Errorf("failed to write data file: %w", err)
 	}
-	tg.Done(id, "updated "+dataFilePath)
+	tr.Done("updated " + dataFilePath)
 	return nil
 }

--- a/internal/pull/executor_test.go
+++ b/internal/pull/executor_test.go
@@ -656,7 +656,7 @@ region: us-east-1
 	}
 
 	// The no-change branch finalises the Targets row with Done("no changes")
-	// — pull is idempotent so a no-op is a successful outcome (output.md §7.3).
+	// — pull is idempotent so a no-op is a successful outcome.
 	foundDone := false
 	for _, call := range reporter.TargetsCalls {
 		for _, tr := range call.Transitions {

--- a/internal/pull/run_on_target_test.go
+++ b/internal/pull/run_on_target_test.go
@@ -1,0 +1,65 @@
+package pull
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	awsInternal "github.com/koh-sh/apcdeploy/internal/aws"
+	"github.com/koh-sh/apcdeploy/internal/batch"
+	"github.com/koh-sh/apcdeploy/internal/config"
+	reportertest "github.com/koh-sh/apcdeploy/internal/reporter/testing"
+)
+
+// TestRunOnTarget_ClientFactoryError covers the early-return path of
+// RunOnTarget when the AWS client factory itself fails. The TargetReporter
+// must be moved to Fail before the helper returns, so the orchestrator's
+// row never stays in "running".
+func TestRunOnTarget_ClientFactoryError(t *testing.T) {
+	t.Parallel()
+
+	failure := errors.New("creds boom")
+	factory := func(ctx context.Context, region string) (*awsInternal.Client, error) {
+		return nil, failure
+	}
+
+	rep := &reportertest.MockReporter{}
+	executor := NewExecutorWithFactory(rep, factory)
+
+	target := &batch.Target{
+		Path: "test.yml",
+		Config: &config.Config{
+			Region:               "us-east-1",
+			Application:          "app",
+			ConfigurationProfile: "profile",
+			Environment:          "env",
+			DataFile:             "/tmp/does-not-matter",
+		},
+		Identifier: "us-east-1/app/profile/env",
+	}
+
+	tg := rep.Targets([]string{target.Identifier})
+	defer tg.Close()
+	tr := batch.NewTargetReporter(tg, target.Identifier)
+
+	err := executor.RunOnTarget(context.Background(), target, tr)
+	if err == nil {
+		t.Fatal("expected error from RunOnTarget when clientFactory fails")
+	}
+	if !errors.Is(err, failure) {
+		t.Errorf("err = %v, want wrapping %v", err, failure)
+	}
+
+	// Targets should have been advanced to a Fail terminal state.
+	var sawFail bool
+	for _, call := range rep.TargetsCalls {
+		for _, tr := range call.Transitions {
+			if tr.Kind == "fail" && tr.ID == target.Identifier {
+				sawFail = true
+			}
+		}
+	}
+	if !sawFail {
+		t.Errorf("expected Targets.Fail for the row; transitions: %+v", rep.TargetsCalls)
+	}
+}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -15,11 +15,10 @@ package reporter
 //   - Error → stderr, always shown.
 //   - Data / Diff → stdout, always shown.
 //
-// Targets is the primary primitive for run/diff/pull/rollback/edit/get/status
-// (docs/design/output.md §4). The older Step / Success / Info / Spin
-// primitives are retained for the init command, which is fundamentally a
-// sequential interactive workflow that does not fit the target-centric
-// model (output.md §11 Q-1, resolved in favour of keeping these primitives).
+// Targets is the primary primitive for run/diff/pull/rollback/edit/get/status.
+// The older Step / Success / Info / Spin primitives are retained for the
+// init command, which is fundamentally a sequential interactive workflow
+// that does not fit the target-centric model.
 type Reporter interface {
 	// Step announces the start of a long-running step. Used by init only;
 	// other commands use Targets.SetPhase.

--- a/internal/reporter/targets.go
+++ b/internal/reporter/targets.go
@@ -52,3 +52,25 @@ type Targets interface {
 	// exactly once; defer it after construction.
 	Close()
 }
+
+// TargetReporter is a single-row view of a Targets primitive. The multi-config
+// orchestrator (internal/batch) hands one of these to each per-target Execute
+// callback so the callback can drive its own row without knowing its
+// identifier or having to share the global Targets handle.
+//
+// Implementations are NOT goroutine-safe by themselves — each TargetReporter
+// is owned by exactly one goroutine, but multiple TargetReporters may write
+// to the same underlying Targets concurrently (the underlying Targets
+// implementation handles its own synchronisation).
+type TargetReporter interface {
+	// SetPhase advances the row's running sub-phase. See Targets.SetPhase.
+	SetPhase(phase, detail string)
+	// SetProgress updates the row's progress bar. See Targets.SetProgress.
+	SetProgress(percent float64, eta time.Duration)
+	// Done finalises the row as successful. See Targets.Done.
+	Done(summary string)
+	// Fail finalises the row as failed. See Targets.Fail.
+	Fail(err error)
+	// Skip finalises the row as skipped. See Targets.Skip.
+	Skip(reason string)
+}

--- a/internal/reporter/targets.go
+++ b/internal/reporter/targets.go
@@ -5,7 +5,7 @@ import "time"
 // Targets is the single Reporter primitive used to render the lifecycle of
 // one or more deployment targets (1 target = 1 line). It replaces the older
 // Step / Success / Spin / Checklist / Progress kinds for command-level
-// output — see docs/design/output.md §4.1.
+// output.
 //
 // Identifiers passed via NewTargets fix the row order; subsequent calls
 // reference each row by that identifier. The implementation MUST tolerate

--- a/internal/reporter/testing/mock_targets.go
+++ b/internal/reporter/testing/mock_targets.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/koh-sh/apcdeploy/internal/reporter"
@@ -32,6 +33,10 @@ type TargetsTransition struct {
 
 // Targets opens a new Targets handle. The returned handle records every
 // transition into the matching TargetsCall entry.
+//
+// The returned handle is safe for concurrent calls — the multi-config
+// orchestrator (internal/batch) drives several targets in parallel from
+// separate goroutines, and tests of that path need a race-free mock.
 func (m *MockReporter) Targets(ids []string) reporter.Targets {
 	idx := len(m.TargetsCalls)
 	m.TargetsCalls = append(m.TargetsCalls, TargetsCall{
@@ -44,6 +49,7 @@ func (m *MockReporter) Targets(ids []string) reporter.Targets {
 type mockTargets struct {
 	m      *MockReporter
 	idx    int
+	mu     sync.Mutex
 	closed bool
 }
 
@@ -68,6 +74,8 @@ func (t *mockTargets) Skip(id, reason string) {
 }
 
 func (t *mockTargets) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.closed {
 		return
 	}
@@ -77,6 +85,8 @@ func (t *mockTargets) Close() {
 }
 
 func (t *mockTargets) record(tr TargetsTransition) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if t.closed {
 		return
 	}

--- a/internal/rollback/executor.go
+++ b/internal/rollback/executor.go
@@ -47,7 +47,7 @@ func NewExecutorWithFactory(rep reporter.Reporter, prom prompt.Prompter, factory
 
 // Execute performs the rollback workflow.
 //
-// Output shape (docs/design/output.md §7.7):
+// Output shape:
 //   - has-ongoing path: optional confirmation block, then a single Targets row
 //     transitioning preparing → stopping → ✓ stopped (deployment #N).
 //   - no-ongoing path: a single Targets row finalized as ⊘ no ongoing deployment.

--- a/internal/run/deploy.go
+++ b/internal/run/deploy.go
@@ -148,9 +148,9 @@ func (d *Deployer) WaitForBakingComplete(ctx context.Context, resolved *aws.Reso
 }
 
 // MakeTargetsDeployTick returns an aws.DeploymentTickFunc that drives a
-// Targets row's deploying sub-phase via SetProgress. Once BAKING (or
-// COMPLETE) is observed the percent pins at 1.0 and the eta is cleared so
-// callers can swap the row to a "baking" sub-phase via SetPhase.
+// row's deploying sub-phase via SetProgress. Once BAKING (or COMPLETE)
+// is observed the percent pins at 1.0 and the eta is cleared so callers
+// can swap the row to a "baking" sub-phase via SetPhase.
 //
 // The "(~N min left)" countdown is derived from wall-clock elapsed time
 // (waitStart) minus the strategy's totalDuration so non-linear strategies
@@ -158,29 +158,30 @@ func (d *Deployer) WaitForBakingComplete(ctx context.Context, resolved *aws.Reso
 //
 // Lives in `run` rather than `internal/aws` or `internal/cli` because the
 // only callers are deploy-shape commands (run + edit). Moving it to either
-// neutral location would introduce a UI dependency in `aws` (Targets is a
-// reporter concept) or an AWS-domain dependency in `cli` (DeploymentState
-// is an AWS type). The `edit → run` import is the lesser evil while the
-// caller set stays at two; revisit if a third caller appears.
-func MakeTargetsDeployTick(tg reporter.Targets, id string) aws.DeploymentTickFunc {
+// neutral location would introduce a UI dependency in `aws` (TargetReporter
+// is a reporter concept) or an AWS-domain dependency in `cli`
+// (DeploymentState is an AWS type). The `edit → run` import is the lesser
+// evil while the caller set stays at two; revisit if a third caller
+// appears.
+func MakeTargetsDeployTick(tr reporter.TargetReporter) aws.DeploymentTickFunc {
 	waitStart := time.Now()
 	return func(state types.DeploymentState, percent float64, totalDuration time.Duration) {
 		if state == types.DeploymentStateBaking || state == types.DeploymentStateComplete {
-			tg.SetProgress(id, 1.0, 0)
+			tr.SetProgress(1.0, 0)
 			return
 		}
 		eta := max(totalDuration-time.Since(waitStart), 0)
-		tg.SetProgress(id, percent/100.0, eta)
+		tr.SetProgress(percent/100.0, eta)
 	}
 }
 
-// MakeTargetsBakeTick returns an aws.BakeTickFunc that updates a Targets
-// row's baking sub-phase detail with the current "(~N min left)" countdown.
+// MakeTargetsBakeTick returns an aws.BakeTickFunc that updates the row's
+// baking sub-phase detail with the current "(~N min left)" countdown.
 // The row is expected to already be in the baking sub-phase (the caller
 // invokes SetPhase("baking", "") before starting the bake wait).
-func MakeTargetsBakeTick(tg reporter.Targets, id string) aws.BakeTickFunc {
+func MakeTargetsBakeTick(tr reporter.TargetReporter) aws.BakeTickFunc {
 	return func(elapsed, total time.Duration) {
-		tg.SetPhase(id, "baking", remainingFromElapsedSuffix(elapsed, total))
+		tr.SetPhase("baking", remainingFromElapsedSuffix(elapsed, total))
 	}
 }
 

--- a/internal/run/deploy.go
+++ b/internal/run/deploy.go
@@ -147,6 +147,44 @@ func (d *Deployer) WaitForBakingComplete(ctx context.Context, resolved *aws.Reso
 	return d.awsClient.WaitForBakingComplete(ctx, resolved.ApplicationID, resolved.EnvironmentID, deploymentNumber, timeout, onTick)
 }
 
+// AWSElapsedForDeploy returns the AWS-recorded deploy phase elapsed:
+// BAKE_TIME_STARTED.OccurredAt - StartedAt. AppConfig records both
+// timestamps at microsecond precision when the corresponding state
+// transitions occur, so this is the authoritative "actual deploy
+// time" — including a few seconds of state-machine overhead that AWS
+// does not document but consistently exhibits (the public
+// GetDeployment example shows ~3.5 s on top of a 15-minute strategy).
+//
+// Falls back to `time.Since(fallback)` when the fetch fails, the
+// EventLog hasn't surfaced BAKE_TIME_STARTED yet, or StartedAt is
+// nil. Best-effort: wall-clock is the only sensible signal when
+// AWS-side data is unavailable.
+func (d *Deployer) AWSElapsedForDeploy(ctx context.Context, resolved *aws.ResolvedResources, deploymentNumber int32, fallback time.Time) time.Duration {
+	details, err := aws.GetDeploymentDetails(ctx, d.awsClient, resolved.ApplicationID, resolved.EnvironmentID, deploymentNumber)
+	if err == nil && details.StartedAt != nil {
+		if bakeStart := aws.BakeTimeStartedAt(details); bakeStart != nil {
+			return bakeStart.Sub(*details.StartedAt)
+		}
+	}
+	return time.Since(fallback)
+}
+
+// AWSElapsedForBake returns the AWS-recorded total elapsed:
+// CompletedAt - StartedAt. AWS does not emit a separate
+// BAKE_TIME_COMPLETED event, so this is the only way to get the
+// authoritative AWS-side total (deploy + bake monitoring + completion
+// overhead).
+//
+// Falls back to `time.Since(fallback)` on fetch failure or when
+// either timestamp is nil.
+func (d *Deployer) AWSElapsedForBake(ctx context.Context, resolved *aws.ResolvedResources, deploymentNumber int32, fallback time.Time) time.Duration {
+	details, err := aws.GetDeploymentDetails(ctx, d.awsClient, resolved.ApplicationID, resolved.EnvironmentID, deploymentNumber)
+	if err == nil && details.StartedAt != nil && details.CompletedAt != nil {
+		return details.CompletedAt.Sub(*details.StartedAt)
+	}
+	return time.Since(fallback)
+}
+
 // MakeTargetsDeployTick returns an aws.DeploymentTickFunc that drives a
 // row's deploying sub-phase via SetProgress. Once BAKING (or COMPLETE)
 // is observed the percent pins at 1.0 and the eta is cleared so callers

--- a/internal/run/deploy_test.go
+++ b/internal/run/deploy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/appconfig/types"
 	awsInternal "github.com/koh-sh/apcdeploy/internal/aws"
 	"github.com/koh-sh/apcdeploy/internal/aws/mock"
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/config"
 	reportertest "github.com/koh-sh/apcdeploy/internal/reporter/testing"
 )
@@ -931,7 +932,7 @@ func TestMakeTargetsDeployTick(t *testing.T) {
 			t.Parallel()
 			m := &reportertest.MockReporter{}
 			tg := m.Targets([]string{"id"})
-			tick := MakeTargetsDeployTick(tg, "id")
+			tick := MakeTargetsDeployTick(batch.NewTargetReporter(tg, "id"))
 			tick(tt.state, tt.percent, tt.totalDuration)
 			tg.Close()
 
@@ -984,7 +985,7 @@ func TestMakeTargetsBakeTick(t *testing.T) {
 			t.Parallel()
 			m := &reportertest.MockReporter{}
 			tg := m.Targets([]string{"id"})
-			tick := MakeTargetsBakeTick(tg, "id")
+			tick := MakeTargetsBakeTick(batch.NewTargetReporter(tg, "id"))
 			tick(tt.elapsed, tt.total)
 			tg.Close()
 

--- a/internal/run/executor.go
+++ b/internal/run/executor.go
@@ -40,14 +40,14 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 // per-target body is shared with the multi-config orchestrator path
 // (RunOnTarget) so both routes produce identical Targets output.
 //
-// Output shape (docs/design/output.md §7.1):
+// Output shape:
 //   - wait none:    ✓ started — v<N>, <Strategy>
 //   - wait-deploy:  ✓ deployed (<elapsed>) — v<N>, <Strategy>, baking started
 //   - wait-bake:    ✓ complete  (<elapsed>) — v<N>, <Strategy>
 //   - no changes:   ⊘ skipped (no changes)
 //   - errors:       ✗ failed: <message>
 //
-// Sub-phases (output.md §3.2):
+// Sub-phases:
 //
 //	preparing → comparing → creating-version → deploying → baking
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {

--- a/internal/run/executor.go
+++ b/internal/run/executor.go
@@ -175,7 +175,7 @@ func (e *Executor) runOnTargetWithDeployer(ctx context.Context, t *batch.Target,
 			tr.Fail(err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}
-		tr.Done(cli.FormatDeploymentSummary("deployed", deployStart, versionNumber, strategyName, "baking started"))
+		tr.Done(cli.FormatDeploymentSummary("deployed", deployer.AWSElapsedForDeploy(ctx, resolved, deploymentNumber, deployStart), versionNumber, strategyName, "baking started"))
 
 	case opts.WaitBake:
 		// waitCtx caps total wait at opts.Timeout. The per-phase timeout
@@ -194,10 +194,10 @@ func (e *Executor) runOnTargetWithDeployer(ctx context.Context, t *batch.Target,
 			tr.Fail(err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}
-		tr.Done(cli.FormatDeploymentSummary("complete", deployStart, versionNumber, strategyName, ""))
+		tr.Done(cli.FormatDeploymentSummary("complete", deployer.AWSElapsedForBake(ctx, resolved, deploymentNumber, deployStart), versionNumber, strategyName, ""))
 
 	default:
-		tr.Done(cli.FormatDeploymentSummary("started", deployStart, versionNumber, strategyName, fmt.Sprintf("deployment #%d", deploymentNumber)))
+		tr.Done(cli.FormatDeploymentSummary("started", 0, versionNumber, strategyName, fmt.Sprintf("deployment #%d", deploymentNumber)))
 	}
 
 	return nil

--- a/internal/run/executor.go
+++ b/internal/run/executor.go
@@ -3,9 +3,11 @@ package run
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/koh-sh/apcdeploy/internal/aws"
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/cli"
 	"github.com/koh-sh/apcdeploy/internal/config"
 	"github.com/koh-sh/apcdeploy/internal/reporter"
@@ -34,7 +36,9 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 	}
 }
 
-// Execute performs the complete deployment workflow.
+// Execute performs the deployment workflow for a single config file. The
+// per-target body is shared with the multi-config orchestrator path
+// (RunOnTarget) so both routes produce identical Targets output.
 //
 // Output shape (docs/design/output.md §7.1):
 //   - wait none:    ✓ started — v<N>, <Strategy>
@@ -46,17 +50,9 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 // Sub-phases (output.md §3.2):
 //
 //	preparing → comparing → creating-version → deploying → baking
-//
-// The deploying sub-phase drives Targets.SetProgress with AppConfig's
-// PercentageComplete so the caller sees a real rollout bar; the baking
-// sub-phase uses Targets.SetPhase("baking", detail) instead because there
-// is no quantified progress to report (it's a monitoring wait).
 func (e *Executor) Execute(ctx context.Context, opts *Options) error {
-	if opts.Timeout < 0 {
-		return fmt.Errorf("timeout must be a non-negative value")
-	}
-	if opts.WaitDeploy && opts.WaitBake {
-		return fmt.Errorf("--wait-deploy and --wait-bake cannot be used together")
+	if err := validateOpts(opts); err != nil {
+		return err
 	}
 
 	cfg, dataContent, err := loadConfiguration(opts.ConfigFile)
@@ -69,56 +65,95 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 		return fmt.Errorf("failed to create deployer: %w", err)
 	}
 
-	id := config.Identifier(deployer.awsClient.Region, cfg)
-	tg := e.reporter.Targets([]string{id})
+	target := &batch.Target{
+		Path:       opts.ConfigFile,
+		Config:     cfg,
+		Identifier: config.Identifier(deployer.awsClient.Region, cfg),
+	}
+
+	tg := e.reporter.Targets([]string{target.Identifier})
 	defer tg.Close()
-	tg.SetPhase(id, "preparing", "")
+	tr := batch.NewTargetReporter(tg, target.Identifier)
+
+	return e.runOnTargetWithDeployer(ctx, target, dataContent, tr, deployer, opts)
+}
+
+// RunOnTarget runs the deployment for one pre-loaded target. Used by the
+// multi-config orchestrator (cmd/run.go wires it via RunOnTargetWithOpts
+// closure since ExecuteFunc has no opts parameter).
+func (e *Executor) RunOnTarget(ctx context.Context, t *batch.Target, tr reporter.TargetReporter, opts *Options) error {
+	if err := validateOpts(opts); err != nil {
+		return err
+	}
+
+	dataContent, err := os.ReadFile(t.Config.DataFile)
+	if err != nil {
+		tr.Fail(err)
+		return fmt.Errorf("failed to read data file %s: %w", t.Config.DataFile, err)
+	}
+
+	deployer, err := e.deployerFactory(ctx, t.Config)
+	if err != nil {
+		tr.Fail(err)
+		return fmt.Errorf("failed to create deployer: %w", err)
+	}
+
+	return e.runOnTargetWithDeployer(ctx, t, dataContent, tr, deployer, opts)
+}
+
+// runOnTargetWithDeployer is the per-target body shared by Execute and
+// RunOnTarget. It assumes the AWS deployer is already constructed and
+// the data file content has been read.
+func (e *Executor) runOnTargetWithDeployer(ctx context.Context, t *batch.Target, dataContent []byte, tr reporter.TargetReporter, deployer *Deployer, opts *Options) error {
+	cfg := t.Config
+
+	tr.SetPhase("preparing", "")
 
 	resolved, err := deployer.ResolveResources(ctx)
 	if err != nil {
-		tg.Fail(id, err)
+		tr.Fail(err)
 		return fmt.Errorf("failed to resolve resources: %w", err)
 	}
 
 	hasOngoing, _, err := deployer.CheckOngoingDeployment(ctx, resolved)
 	if err != nil {
-		tg.Fail(id, err)
+		tr.Fail(err)
 		return fmt.Errorf("failed to check ongoing deployments: %w", err)
 	}
 	if hasOngoing {
 		ongoingErr := fmt.Errorf("deployment already in progress")
-		tg.Fail(id, ongoingErr)
+		tr.Fail(ongoingErr)
 		return ongoingErr
 	}
 
 	contentType, err := deployer.DetermineContentType(resolved.Profile.Type, cfg.DataFile)
 	if err != nil {
-		tg.Fail(id, err)
+		tr.Fail(err)
 		return fmt.Errorf("failed to determine content type: %w", err)
 	}
 
 	if err := deployer.ValidateLocalData(dataContent, contentType); err != nil {
-		tg.Fail(id, err)
+		tr.Fail(err)
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
 	if !opts.Force {
-		tg.SetPhase(id, "comparing", "")
+		tr.SetPhase("comparing", "")
 		hasChanges, err := deployer.HasConfigurationChanges(ctx, resolved, dataContent, cfg.DataFile, contentType)
 		if err != nil {
-			tg.Fail(id, err)
+			tr.Fail(err)
 			return fmt.Errorf("failed to check for changes: %w", err)
 		}
 		if !hasChanges {
-			tg.Skip(id, "skipped (no changes)")
+			tr.Skip("skipped (no changes)")
 			return nil
 		}
 	}
 
-	tg.SetPhase(id, "creating-version", "")
+	tr.SetPhase("creating-version", "")
 	versionNumber, err := deployer.CreateVersion(ctx, resolved, dataContent, contentType, opts.Description)
 	if err != nil {
-		tg.Fail(id, err)
+		tr.Fail(err)
 		if aws.IsValidationError(err) {
 			return fmt.Errorf("%s", aws.FormatValidationError(err))
 		}
@@ -126,45 +161,58 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 	}
 
 	deployStart := time.Now()
-	tg.SetPhase(id, "deploying", "")
+	tr.SetPhase("deploying", "")
 	deploymentNumber, err := deployer.StartDeployment(ctx, resolved, versionNumber, opts.Description)
 	if err != nil {
-		tg.Fail(id, err)
+		tr.Fail(err)
 		return fmt.Errorf("failed to start deployment: %w", err)
 	}
 
 	strategyName := cfg.DeploymentStrategy
 	switch {
 	case opts.WaitDeploy:
-		if err := deployer.WaitForDeploymentPhase(ctx, resolved, deploymentNumber, false, opts.Timeout, MakeTargetsDeployTick(tg, id)); err != nil {
-			tg.Fail(id, err)
+		if err := deployer.WaitForDeploymentPhase(ctx, resolved, deploymentNumber, false, opts.Timeout, MakeTargetsDeployTick(tr)); err != nil {
+			tr.Fail(err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}
-		tg.Done(id, cli.FormatDeploymentSummary("deployed", deployStart, versionNumber, strategyName, "baking started"))
+		tr.Done(cli.FormatDeploymentSummary("deployed", deployStart, versionNumber, strategyName, "baking started"))
 
 	case opts.WaitBake:
-		// waitCtx caps total wait at opts.Timeout. The per-phase timeout passed
-		// below is the remaining budget against that deadline so the inner
-		// Wait* timeout reflects "how long this phase may still take".
+		// waitCtx caps total wait at opts.Timeout. The per-phase timeout
+		// passed below is the remaining budget against that deadline so the
+		// inner Wait* timeout reflects "how long this phase may still take".
 		deadline := time.Now().Add(time.Duration(opts.Timeout) * time.Second)
 		waitCtx, cancel := context.WithDeadline(ctx, deadline)
 		defer cancel()
 
-		if err := deployer.WaitForDeploymentPhase(waitCtx, resolved, deploymentNumber, false, remainingSeconds(deadline), MakeTargetsDeployTick(tg, id)); err != nil {
-			tg.Fail(id, err)
+		if err := deployer.WaitForDeploymentPhase(waitCtx, resolved, deploymentNumber, false, remainingSeconds(deadline), MakeTargetsDeployTick(tr)); err != nil {
+			tr.Fail(err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}
-		tg.SetPhase(id, "baking", "")
-		if err := deployer.WaitForBakingComplete(waitCtx, resolved, deploymentNumber, remainingSeconds(deadline), MakeTargetsBakeTick(tg, id)); err != nil {
-			tg.Fail(id, err)
+		tr.SetPhase("baking", "")
+		if err := deployer.WaitForBakingComplete(waitCtx, resolved, deploymentNumber, remainingSeconds(deadline), MakeTargetsBakeTick(tr)); err != nil {
+			tr.Fail(err)
 			return fmt.Errorf("deployment failed: %w", err)
 		}
-		tg.Done(id, cli.FormatDeploymentSummary("complete", deployStart, versionNumber, strategyName, ""))
+		tr.Done(cli.FormatDeploymentSummary("complete", deployStart, versionNumber, strategyName, ""))
 
 	default:
-		tg.Done(id, cli.FormatDeploymentSummary("started", deployStart, versionNumber, strategyName, fmt.Sprintf("deployment #%d", deploymentNumber)))
+		tr.Done(cli.FormatDeploymentSummary("started", deployStart, versionNumber, strategyName, fmt.Sprintf("deployment #%d", deploymentNumber)))
 	}
 
+	return nil
+}
+
+// validateOpts checks Options invariants that don't depend on AWS state.
+// Extracted so single-target Execute and the multi-config orchestrator
+// path apply the same checks before doing any AWS work.
+func validateOpts(opts *Options) error {
+	if opts.Timeout < 0 {
+		return fmt.Errorf("timeout must be a non-negative value")
+	}
+	if opts.WaitDeploy && opts.WaitBake {
+		return fmt.Errorf("--wait-deploy and --wait-bake cannot be used together")
+	}
 	return nil
 }
 

--- a/internal/run/executor_test.go
+++ b/internal/run/executor_test.go
@@ -263,7 +263,7 @@ region: us-east-1
 	// Run now reports phases through a single Targets row that progresses
 	// through preparing → comparing → creating-version → deploying, then
 	// finalises with Done("started — vN, Strategy, deployment #N") when no
-	// wait flag is set (output.md §7.1).
+	// wait flag is set.
 	if len(reporter.TargetsCalls) != 1 {
 		t.Fatalf("expected exactly 1 Targets call, got %d", len(reporter.TargetsCalls))
 	}

--- a/internal/run/run_on_target_test.go
+++ b/internal/run/run_on_target_test.go
@@ -1,0 +1,101 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/koh-sh/apcdeploy/internal/batch"
+	"github.com/koh-sh/apcdeploy/internal/config"
+	reportertest "github.com/koh-sh/apcdeploy/internal/reporter/testing"
+)
+
+// TestRunOnTarget_DeployerFactoryError covers the early-return path of
+// RunOnTarget when the deployer factory fails (e.g. AWS client creation
+// error). The TargetReporter must be moved to Fail before the helper
+// returns so the orchestrator's row never stays in "running".
+func TestRunOnTarget_DeployerFactoryError(t *testing.T) {
+	t.Parallel()
+
+	failure := errors.New("creds boom")
+	factory := func(ctx context.Context, cfg *config.Config) (*Deployer, error) {
+		return nil, failure
+	}
+
+	rep := &reportertest.MockReporter{}
+	executor := NewExecutorWithFactory(rep, factory)
+
+	// Need an actual data file so RunOnTarget gets past the os.ReadFile
+	// step before reaching deployerFactory.
+	dataPath := t.TempDir() + "/data.json"
+	if err := os.WriteFile(dataPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+
+	target := &batch.Target{
+		Path: "test.yml",
+		Config: &config.Config{
+			Region:               "us-east-1",
+			Application:          "app",
+			ConfigurationProfile: "profile",
+			Environment:          "env",
+			DataFile:             dataPath,
+		},
+		Identifier: "us-east-1/app/profile/env",
+	}
+
+	tg := rep.Targets([]string{target.Identifier})
+	defer tg.Close()
+	tr := batch.NewTargetReporter(tg, target.Identifier)
+
+	err := executor.RunOnTarget(context.Background(), target, tr, &Options{Timeout: 30})
+	if err == nil {
+		t.Fatal("expected error from RunOnTarget when deployerFactory fails")
+	}
+	if !errors.Is(err, failure) {
+		t.Errorf("err = %v, want wrapping %v", err, failure)
+	}
+
+	var sawFail bool
+	for _, call := range rep.TargetsCalls {
+		for _, tr := range call.Transitions {
+			if tr.Kind == "fail" && tr.ID == target.Identifier {
+				sawFail = true
+			}
+		}
+	}
+	if !sawFail {
+		t.Errorf("expected Targets.Fail for the row; transitions: %+v", rep.TargetsCalls)
+	}
+}
+
+// TestRunOnTarget_ValidatesOptsBeforeAWS covers RunOnTarget's
+// validateOpts call: invalid options must be rejected without making
+// any AWS / file calls.
+func TestRunOnTarget_ValidatesOptsBeforeAWS(t *testing.T) {
+	t.Parallel()
+
+	executor := NewExecutorWithFactory(&reportertest.MockReporter{},
+		func(ctx context.Context, cfg *config.Config) (*Deployer, error) {
+			t.Fatal("deployerFactory must not be called when opts are invalid")
+			return nil, nil
+		},
+	)
+	target := &batch.Target{
+		Identifier: "us-east-1/app/profile/env",
+		Config:     &config.Config{Region: "us-east-1"},
+	}
+	rep := &reportertest.MockReporter{}
+	tg := rep.Targets([]string{target.Identifier})
+	defer tg.Close()
+	tr := batch.NewTargetReporter(tg, target.Identifier)
+
+	err := executor.RunOnTarget(context.Background(), target, tr, &Options{
+		WaitDeploy: true,
+		WaitBake:   true,
+	})
+	if err == nil {
+		t.Fatal("expected error for conflicting wait flags")
+	}
+}

--- a/internal/status/executor.go
+++ b/internal/status/executor.go
@@ -38,7 +38,7 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 
 // Execute performs the status check workflow.
 //
-// Output shape (docs/design/output.md §7.4):
+// Output shape:
 //   - found: ✓ <STATE> — v<N> [(deployed/started X ago)] on the Targets row,
 //     followed by display.DeploymentStatus's Header + Table on stderr and the
 //     state name on stdout.
@@ -85,8 +85,8 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 
 	if deploymentInfo == nil {
 		tg.Skip(id, "no deployment")
-		// stdout payload is fixed at "NONE\n" so scripts can branch on it
-		// (output.md §7.4 (b)). Always emitted, even under --silent.
+		// stdout payload is fixed at "NONE\n" so scripts can branch on it.
+		// Always emitted, even under --silent.
 		e.reporter.Data([]byte("NONE\n"))
 		e.reporter.Box("", []string{
 			"No deployment has been created yet for this profile/environment.",
@@ -96,22 +96,19 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 	}
 
 	tg.Done(id, summarizeDeployment(deploymentInfo))
-	// Two output systems intentionally coexist on the success path
-	// (output.md §11 Q-2 — to be revisited when status grows multi-target
-	// support). The Targets row is the at-a-glance summary
-	// ("✓ COMPLETE — v42 (2h ago)"); display.DeploymentStatus follows with
-	// the structured Header + Table that surfaces the full deployment
-	// metadata (Deployment Number, strategy, started/completed timestamps).
-	// In TTY mode the Targets renderer has already finalised by the time
-	// the table prints, so the two views stack cleanly without competing
-	// for the cursor.
+	// Two output systems intentionally coexist on the success path. The
+	// Targets row is the at-a-glance summary ("✓ COMPLETE — v42 (2h ago)");
+	// display.DeploymentStatus follows with the structured Header + Table
+	// that surfaces the full deployment metadata (Deployment Number,
+	// strategy, started/completed timestamps). In TTY mode the Targets
+	// renderer has already finalised by the time the table prints, so the
+	// two views stack cleanly without competing for the cursor.
 	display.DeploymentStatus(e.reporter, deploymentInfo, cfg, resources)
 	return nil
 }
 
 // summarizeDeployment renders the post-icon Targets summary for a deployment.
-// Format: "<STATE> [<percent>%] — v<ConfigVersion>[ (<verb> <relative-time>)]"
-// per docs/design/output.md §7.4 (a)/(a').
+// Format: "<STATE> [<percent>%] — v<ConfigVersion>[ (<verb> <relative-time>)]".
 func summarizeDeployment(d *aws.DeploymentDetails) string {
 	state := string(d.State)
 	summary := state

--- a/internal/status/executor_test.go
+++ b/internal/status/executor_test.go
@@ -147,7 +147,7 @@ region: us-east-1
 
 	err = executor.Execute(context.Background(), opts)
 	// Status returns aws.ErrNoDeployment for the no-deployment case so
-	// cmd/root.go can map it to exit code 2 (output.md §7.4 (d) / §8.6).
+	// cmd/root.go can map it to exit code 2.
 	if !errors.Is(err, awsInternal.ErrNoDeployment) {
 		t.Fatalf("expected aws.ErrNoDeployment, got: %v", err)
 	}

--- a/llms.md
+++ b/llms.md
@@ -436,9 +436,31 @@ apcdeploy ls-resources --region us-west-2 --json --silent > resources.json
 
 Available for all commands:
 
-- `-c, --config <path>`: Configuration file path (default: `apcdeploy.yml`)
+- `-c, --config <path>`: Configuration file path (default: `apcdeploy.yml`). May be repeated for `run` / `diff` / `pull` to operate on several configs in one invocation; all other commands accept exactly one `-c` and reject multiple.
 - `-s, --silent`: Suppress verbose output, show only essential information (useful for CI/CD and scripting)
   - **Note for AI Assistants**: Do not use `--silent` when executing commands via AI agents. Verbose output is essential for debugging and understanding command execution.
+
+### Multi-config Mode (run / diff / pull)
+
+`run`, `diff`, and `pull` support running against multiple configurations in one invocation. Pass `-c` repeatedly:
+
+```bash
+apcdeploy diff -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml
+apcdeploy run  -c environments/*.yml --parallel 3 --wait-bake
+apcdeploy pull -c environments/*.yml --continue-on-error
+```
+
+Behavior (defined in `docs/design/multi-config.md`):
+
+- Each `-c` is loaded and validated up-front; any single load failure aborts the batch before any AWS call.
+- Targets are identified by the 4-tuple `region/app/profile/env`. Two configs that resolve to the same identifier produce `ErrDuplicateTarget`.
+- Default execution is fully parallel. Use `--parallel N` to cap concurrency or `--parallel 1` for strict serial order.
+- Default failure mode is fail-fast: queued targets that haven't started yet are reported as `⊘ skipped (fail-fast)`. Use `--continue-on-error` to run every target regardless of failures.
+- Each target's `--timeout` is independent (it is per-target, not a global wall-clock cap).
+- After all targets settle, a single aggregate line is printed: `N ok, N no-op, N failed [(elapsed)]`. Failed targets are also expanded into an `Errors:` section with optional `Resolution:` hints.
+- `diff`'s stdout is buffered per target and emitted in argument order (so the combined diff stream is deterministic regardless of completion order). Each per-target body is prefixed with `=== <region>/<app>/<profile>/<env> ===`. Single-target output (`-c` once) keeps the existing no-header format so the body still pipes into `patch` / `git apply`.
+- Multi-config requires `region:` to be set in each yml. Single-config keeps the SDK-default region resolution as before.
+- **For AI assistants**: prefer single-target invocations unless the multi-config behavior is explicitly desired. Multi-target output is denser and harder to read step-by-step; failures are aggregated at the end of the run.
 
 ### init command
 

--- a/llms.md
+++ b/llms.md
@@ -450,7 +450,7 @@ apcdeploy run  -c environments/*.yml --parallel 3 --wait-bake
 apcdeploy pull -c environments/*.yml --continue-on-error
 ```
 
-Behavior (defined in `docs/design/multi-config.md`):
+Behavior:
 
 - Each `-c` is loaded and validated up-front; any single load failure aborts the batch before any AWS call.
 - Targets are identified by the 4-tuple `region/app/profile/env`. Two configs that resolve to the same identifier produce `ErrDuplicateTarget`.


### PR DESCRIPTION
## Summary
- Implements `docs/design/multi-config.md` (PR-2 / Track C). `run`, `diff`, `pull` now accept `-c` repeatedly to operate on multiple configs in one invocation, via a shared `internal/batch` orchestrator with parallel / fail-fast / `--continue-on-error` semantics.
- Single-config path is preserved (no behavior change for `-c` once or absent); the orchestrator path activates when 2+ `-c` are passed.
- Bundled fixes that surfaced during dogfooding: TTY row rendering for long error messages (`…` truncation) and accurate `--wait-deploy` / `--wait-bake` elapsed time using AWS-recorded event timestamps.

### Multi-config (P2 / P6 / P7-P9)
- `internal/batch/`: `Target`, `LoadAll` (pre-loads + validates every `-c`, dedups path-equivalent inputs, errors on identifier-level duplicates), `Orchestrator` (worker pool with FIFO start order, optional `Parallel` cap, fail-fast or `ContinueOnError`, returns `Summary`).
- `internal/reporter/Targets`: gains `TargetReporter` view so per-target executor callbacks don't carry their identifier.
- `run`/`diff`/`pull` executors: extract per-target body into `runOnTargetWith*`; `Execute` (single) and `RunOnTarget` (orchestrator) both delegate so output is bit-identical between paths.
- `cmd/{run,diff,pull}.go`: dispatch on `len(configFiles)`. Multi-target path emits the aggregate `N ok, N no-op, N failed [(elapsed)]` line and an `Errors:` section with optional Resolution hints.
- `cmd/diff.go`: stdout payloads buffered and flushed in argument order (output.md §10.4) with `=== <id> ===` headers per target. Single-target keeps the no-header contract for `patch` / `git apply` piping.
- `cmd/root.go`: global `-c` becomes `StringSliceVar`. Single-config commands (`init`/`get`/`status`/`rollback`) call `requireSingleConfig` and reject multiple `-c`.

### TTY render fix
- `internal/cli/Targets`: long row payloads (errMsg / summary / detail / reason) are truncated to fit terminal width before rendering. Without this, AWS errors that exceeded the terminal width wrapped to multiple visual lines and broke the `\033[NA` redraw cursor math, so previous frames accumulated as ghost text in the row.
- `cli.TerminalCols(*os.File)` + `terminalColsOf` wrapper; `cli.truncateRunes` for rune-aware truncation; `\033[J` clear-to-end as belt-and-suspenders for SIGWINCH narrowing mid-run.

### Elapsed-time accuracy (run / edit `--wait-*`)
- Previously `time.Since(deployStart)` (wall-clock), which absorbed up to one polling-tick of lag (default 5s) before the apcdeploy poll loop noticed the AWS state transition.
- Now uses AWS-recorded timestamps: `BAKE_TIME_STARTED.OccurredAt - StartedAt` for `--wait-deploy`; `CompletedAt - StartedAt` for `--wait-bake` (AWS does not emit a separate `BAKE_TIME_COMPLETED` event).
- `cli.FormatDeploymentSummary` signature changed from `(verb, start time.Time, ...)` to `(verb, elapsed time.Duration, ...)`. `cli.FormatElapsed` keeps Round-to-nearest-second so the displayed value matches AppConfig's microsecond timestamps with minimum error.
- AWS state-machine adds a few seconds of overhead (the public `GetDeployment` example shows ~3.5s on a 15-minute strategy and ~6s of finalisation overhead even with `FinalBakeTimeInMinutes: 0`); this is the AWS-recorded reality and is now visible in the display.

### Docs
- `CLAUDE.md`: multi-config CLI examples + new `internal/batch` section.
- `README.md`: updated `-c` description and `run` / `diff` / `pull` sections with `--parallel` / `--continue-on-error`.
- `llms.md`: new "Multi-config Mode" section.
- `.claude/rules/output-contract.md`: documented exception for the aggregate summary + Errors section, new "Multi-config orchestration" section.

## Test plan
- [x] `mise run ci` passes (90.0% coverage)
- [x] `mise run e2e-run` passes (S1 → S9 + E1 → E5; new S3 covers multi-target run/diff/pull, dedup, single-config rejection)
- [x] Manual TTY observation via `tmp/mc/test.sh 1`-`9` (parallel rendering, identifier alignment, progress bar / ETA, Done / Skip / Fail rows, `=== <id> ===` headers in stdout, aggregate summary, long-error truncation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)