### PR TITLE
refactor(e2e): split monolithic script into runner + cases + lib

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,13 @@ E2E tests require AWS credentials and use Terraform to provision resources:
 - **Clean up**: `mise run e2e-clean` (destroys test resources)
 - **Full workflow**: `mise run e2e-full` (setup, test, cleanup in one command)
 
+The runner (`e2e/e2e-test.sh`) drives per-scenario case files in
+`e2e/cases/` (S1–S9 success scenarios, E1–E5 error scenarios) using shared
+helpers in `e2e/lib/` (`common.sh` for env / output / traps, `assert.sh`
+for assertions, `apc.sh` for CLI wrappers and fixture helpers). Run a
+subset by passing section IDs (`./e2e/e2e-test.sh S1 S3`); set
+`E2E_KEEP_TMP=1` to keep per-section tempdirs for debugging.
+
 ## Architecture
 
 ### Command Structure (Cobra-based)

--- a/e2e/cases/e1_resource_errors.sh
+++ b/e2e/cases/e1_resource_errors.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# E1: Non-existent application / profile / environment all fail init.
+
+section "E1" "Resource errors"
+
+step "init with unknown application fails"
+expect_fail "$APCDEPLOY_BIN" init --silent --region "$REGION" \
+    --app xxx --profile test --env dev
+
+step "init with unknown profile fails"
+expect_fail "$APCDEPLOY_BIN" init --silent --region "$REGION" \
+    --app "$APP" --profile xxx --env dev
+
+step "init with unknown environment fails"
+expect_fail "$APCDEPLOY_BIN" init --silent --region "$REGION" \
+    --app "$APP" --profile json-freeform --env xxx

--- a/e2e/cases/e2_validation.sh
+++ b/e2e/cases/e2_validation.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# E2: Client-side validation rejects malformed JSON before any AWS call.
+
+section "E2" "Validation"
+
+step "init json-freeform/dev"
+apc_init json-freeform dev
+
+step "run with broken JSON exits non-zero"
+apc_write_json '{"bad": json}'
+expect_fail "$APCDEPLOY_BIN" run --silent

--- a/e2e/cases/e3_constraints.sh
+++ b/e2e/cases/e3_constraints.sh
@@ -20,7 +20,10 @@ __e3_cleanup_bg() {
         __e3_bg_active=0
     fi
 }
-# Compose with the per-section finalizer registered by e2e-test.sh.
+# This overrides the per-section `trap '__finalize_step ok' EXIT` registered
+# by e2e-test.sh, so we re-invoke __finalize_step explicitly to keep the
+# trailing ✓ of the last step. Anything else the runner expects on EXIT
+# must be added here too.
 trap '__e3_cleanup_bg; __finalize_step ok' EXIT
 
 step "start a slow deploy in the background"

--- a/e2e/cases/e3_constraints.sh
+++ b/e2e/cases/e3_constraints.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# E3: Concurrency / timeout — second run while first is in flight, edit
+# during deploy, and per-call --timeout enforcement.
+
+section "E3" "Constraints"
+
+# Track the slow background deploy so we can stop both the local process
+# and the AWS-side rollout if a later step short-circuits via set -e.
+__e3_bg_pid=""
+__e3_bg_active=0
+__e3_cleanup_bg() {
+    if [[ -n "$__e3_bg_pid" ]]; then
+        kill "$__e3_bg_pid" 2>/dev/null || true
+        wait "$__e3_bg_pid" 2>/dev/null || true
+    fi
+    if (( __e3_bg_active )); then
+        # Best-effort: stop the AWS rollout so the next section doesn't
+        # see ConflictException on the same profile.
+        "$APCDEPLOY_BIN" rollback --yes --silent >/dev/null 2>&1 || true
+        __e3_bg_active=0
+    fi
+}
+# Compose with the per-section finalizer registered by e2e-test.sh.
+trap '__e3_cleanup_bg; __finalize_step ok' EXIT
+
+step "start a slow deploy in the background"
+apc_init error-test dev
+apc_use_strategy "$SLOW_STRATEGY"
+apc_write_json '{"c":"1"}'
+"$APCDEPLOY_BIN" run --silent >/dev/null 2>&1 &
+__e3_bg_pid=$!
+__e3_bg_active=1
+# Poll status until AWS reports the deploy is in flight (DEPLOYING/BAKING).
+# `sleep N` is fragile under CI load — the next step depends on AWS
+# actually being mid-rollout, not on wall-clock time.
+for _ in $(seq 1 30); do
+    state=$(apc_combined status --silent 2>/dev/null || true)
+    [[ "$state" == *DEPLOYING* || "$state" == *BAKING* ]] && break
+    sleep 1
+done
+[[ "$state" == *DEPLOYING* || "$state" == *BAKING* ]] \
+    || fail "background deploy never reached DEPLOYING/BAKING (state=$state)"
+
+step "second run during ongoing deploy is rejected"
+expect_fail "$APCDEPLOY_BIN" run --silent
+
+step "edit during ongoing deploy is rejected"
+expect_fail env EDITOR="$FAKE_EDITOR" APCDEPLOY_EDIT_CONTENT='{"c":"x"}' \
+    "$APCDEPLOY_BIN" edit --region "$REGION" --app "$APP" \
+    --profile error-test --env dev --silent
+
+# Reap the backgrounded run so its rollout doesn't leak into later sections.
+wait "$__e3_bg_pid" 2>/dev/null || true
+__e3_bg_pid=""
+__e3_bg_active=0
+
+step "--wait-bake --timeout 5 fails fast on the slow strategy"
+apc_write_json '{"c":"2"}'
+expect_fail "$APCDEPLOY_BIN" run --wait-bake --timeout 5 --silent

--- a/e2e/cases/e4_file_errors.sh
+++ b/e2e/cases/e4_file_errors.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# E4: File-shape errors — missing config, invalid yml, init refuses overwrite.
+
+section "E4" "File errors"
+
+step "run with non-existent --config fails"
+expect_fail "$APCDEPLOY_BIN" run --config xxx.yml --silent
+
+step "run with apcdeploy.yml missing 'application:' fails"
+apc_init json-freeform dev
+apc_remove_field application
+expect_fail "$APCDEPLOY_BIN" run --silent
+
+step "init refuses to overwrite without --force"
+apc_init json-freeform dev
+expect_fail "$APCDEPLOY_BIN" init --silent --region "$REGION" \
+    --app "$APP" --profile json-freeform --env dev
+
+step "init --force overwrites successfully"
+apc_init json-freeform dev

--- a/e2e/cases/e5_edge_cases.sh
+++ b/e2e/cases/e5_edge_cases.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# E5: Edge cases — no-deployment notice, exit code 2 sentinel, invalid timeout.
+
+section "E5" "Edge cases"
+
+step "init error-test/staging (assumed to have no prior deployment)"
+apc_init error-test staging
+apc_use_strategy
+# init does not create data.json when there is no prior deployment, so we
+# write a placeholder ourselves; diff/status only care about the AWS-side
+# absence of a prior deployment, but they still need to be able to load
+# the local data file. (In the original e2e-test.sh this was masked by
+# stale data.json leaking from earlier sections in the shared cwd.)
+apc_write_json '{"e":"1"}'
+
+step "diff reports 'no prior deployment' on stderr"
+out=$(apc_combined diff || true)
+assert_contains "$out" "no prior deployment" "diff stderr"
+
+step "status reports 'no deployment' on stderr"
+out=$(apc_combined status || true)
+assert_contains "$out" "no deployment" "status stderr"
+
+step "pull exits with code 2 sentinel when no prior deployment"
+expect_exit 2 "$APCDEPLOY_BIN" pull --silent
+
+step "edit exits with code 2 sentinel when no prior deployment"
+expect_exit 2 env EDITOR="$FAKE_EDITOR" APCDEPLOY_EDIT_CONTENT='{"e":"x"}' \
+    "$APCDEPLOY_BIN" edit --region "$REGION" --app "$APP" \
+    --profile error-test --env staging --silent
+
+step "run with negative --timeout fails"
+expect_fail "$APCDEPLOY_BIN" run --wait-bake --timeout -1 --silent

--- a/e2e/cases/s1_workflow.sh
+++ b/e2e/cases/s1_workflow.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# S1: Basic workflow — ls-resources → init → diff → run → status → get → pull.
+# Sourced by e2e-test.sh inside a per-section tempdir.
+
+section "S1" "Basic workflow"
+
+step "ls-resources lists the test app + region"
+ls_json=$(apc_stdout ls-resources --region "$REGION" --json --silent)
+assert_jq <(printf '%s' "$ls_json") ".region == \"$REGION\""
+assert_jq <(printf '%s' "$ls_json") '.applications | length > 0'
+assert_jq <(printf '%s' "$ls_json") \
+    "[.applications[].name] | index(\"$APP\") != null"
+
+step "ls-resources --show-strategies includes AppConfig.AllAtOnce"
+ls_strat=$(apc_stdout ls-resources --region "$REGION" \
+    --show-strategies --json --silent)
+assert_jq <(printf '%s' "$ls_strat") \
+    '[.deployment_strategies[].name] | index("AppConfig.AllAtOnce") != null'
+
+step "init creates apcdeploy.yml + data.json"
+apc_init json-freeform dev
+apc_use_strategy
+apc_write_json '{"v":"1"}'
+
+step "diff (non-silent) emits a Targets transition on stderr"
+diff_out=$(apc_combined diff || true)
+assert_match "$diff_out" \
+    '(no changes|no prior deployment|diff \()' "diff progress"
+
+step "diff stdout contains the data payload"
+diff_stdout=$(apc_stdout diff || true)
+assert_contains "$diff_stdout" 'v' "diff body"
+
+step "diff --silent suppresses progress on stderr"
+silent_err=$(apc_combined diff --silent || true)
+assert_not_contains "$silent_err" "no changes" "silent stderr"
+assert_not_contains "$silent_err" "diff (" "silent stderr"
+
+step "run --wait-bake completes deployment"
+apc_quiet run --wait-bake --silent
+
+step "status reports COMPLETE"
+status_out=$(apc_stdout status --silent)
+assert_contains "$status_out" "COMPLETE" "status"
+
+step "get returns deployed payload v=1"
+get_out=$(apc_stdout get --silent --yes)
+assert_jq <(printf '%s' "$get_out") '.v == "1"'
+
+step "pull restores deployed state after local modification"
+apc_write_json '{"v":"modified"}'
+apc_quiet pull --silent
+assert_jq data.json '.v == "1"'
+
+step "round-trip: deploy v=2, get returns v=2"
+apc_write_json '{"v":"2"}'
+apc_quiet run --wait-bake --silent
+get_out=$(apc_stdout get --silent --yes)
+assert_jq <(printf '%s' "$get_out") '.v == "2"'

--- a/e2e/cases/s2_content_types.sh
+++ b/e2e/cases/s2_content_types.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# S2: ContentType handling — FeatureFlags JSON, YAML, plain text.
+# Each profile is deployed and then round-tripped to confirm the content
+# type is honored end to end.
+#
+# FeatureFlags uses pull rather than get because the AppConfig Data API
+# returns evaluated flag values (e.g. `{"test":{}}`) — the raw flags
+# definition is only retrievable via the hosted-version endpoint, which
+# pull uses.
+
+section "S2" "Content types"
+
+step "FeatureFlags profile deploys and round-trips through pull"
+apc_init json-featureflags dev
+apc_use_strategy
+apc_write_json '{"version":"1","flags":{"test":{"name":"test"}}}'
+apc_quiet run --wait-bake --silent
+# Mutate the local file so pull has something to overwrite.
+apc_write_json '{"version":"1","flags":{"placeholder":{"name":"x"}}}'
+apc_quiet pull --silent
+assert_jq data.json '.flags.test.name == "test"'
+
+step "YAML profile deploys and round-trips literal content"
+apc_init yaml-config dev
+apc_use_strategy
+apc_write_yaml $'v: 1\nk: v'
+apc_quiet run --wait-bake --silent
+yaml_out=$(apc_stdout get --silent --yes)
+assert_contains "$yaml_out" "v: 1" "yaml body"
+assert_contains "$yaml_out" "k: v" "yaml body"
+
+step "Text profile deploys and round-trips literal content"
+apc_init text-config dev
+apc_use_strategy
+apc_write_text 'hello-text-payload'
+apc_quiet run --wait-bake --silent
+text_out=$(apc_stdout get --silent --yes)
+assert_contains "$text_out" "hello-text-payload" "text body"

--- a/e2e/cases/s3_multiconfig.sh
+++ b/e2e/cases/s3_multiconfig.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# S3: Multi-config orchestration — `-c` repeated for run/diff/pull.
+# Must run before any later section perturbs json-freeform/{dev,staging}.
+
+section "S3" "Multi-config"
+
+mc_dir=multi-config
+mkdir -p "$mc_dir/dev" "$mc_dir/stg"
+
+step "init populates per-target apcdeploy.yml under multi-config/{dev,stg}"
+( cd "$mc_dir/dev" && apc_quiet init --silent --force \
+    --app "$APP" --region "$REGION" --profile json-freeform --env dev )
+( cd "$mc_dir/stg" && apc_quiet init --silent --force \
+    --app "$APP" --region "$REGION" --profile json-freeform --env staging )
+
+step "tweak strategy + data per target"
+for d in "$mc_dir/dev" "$mc_dir/stg"; do
+    ( cd "$d" && apc_use_strategy )
+done
+printf '%s' '{"mc":"dev-1"}' > "$mc_dir/dev/data.json"
+printf '%s' '{"mc":"stg-1"}' > "$mc_dir/stg/data.json"
+
+step "multi-config run --wait-bake deploys both targets"
+apc_quiet run --wait-bake --silent \
+    -c "$mc_dir/dev/apcdeploy.yml" -c "$mc_dir/stg/apcdeploy.yml"
+
+step "get against each target returns its own payload"
+dev_out=$(apc_stdout get --silent --yes -c "$mc_dir/dev/apcdeploy.yml")
+stg_out=$(apc_stdout get --silent --yes -c "$mc_dir/stg/apcdeploy.yml")
+assert_jq <(printf '%s' "$dev_out") '.mc == "dev-1"'
+assert_jq <(printf '%s' "$stg_out") '.mc == "stg-1"'
+
+step "multi-config diff reports no changes for both targets"
+out=$(apc_combined diff \
+    -c "$mc_dir/dev/apcdeploy.yml" -c "$mc_dir/stg/apcdeploy.yml" || true)
+assert_match "$out" "no changes" "diff progress"
+
+step "diff body shows === <id> === only for the changed target"
+printf '{"mc":"dev-2"}' > "$mc_dir/dev/data.json"
+diff_out=$(apc_stdout diff \
+    -c "$mc_dir/dev/apcdeploy.yml" -c "$mc_dir/stg/apcdeploy.yml" || true)
+assert_contains "$diff_out" "=== ${REGION}/${APP}/json-freeform/dev ===" "diff header"
+assert_not_contains "$diff_out" \
+    "=== ${REGION}/${APP}/json-freeform/staging ===" "diff header"
+
+step "multi-config pull restores changed target"
+apc_quiet pull --silent \
+    -c "$mc_dir/dev/apcdeploy.yml" -c "$mc_dir/stg/apcdeploy.yml"
+assert_jq "$mc_dir/dev/data.json" '.mc == "dev-1"'
+assert_jq "$mc_dir/stg/data.json" '.mc == "stg-1"'
+
+step "path-level dedup: same -c twice is collapsed silently"
+apc_quiet diff --silent \
+    -c "$mc_dir/dev/apcdeploy.yml" -c "$mc_dir/dev/apcdeploy.yml"
+
+step "identifier-level dedup: distinct paths same 4-tuple is rejected"
+mkdir -p "$mc_dir/dup"
+cp "$mc_dir/dev/apcdeploy.yml" "$mc_dir/dup/apcdeploy.yml"
+cp "$mc_dir/dev/data.json" "$mc_dir/dup/data.json"
+expect_fail "$APCDEPLOY_BIN" diff --silent \
+    -c "$mc_dir/dev/apcdeploy.yml" -c "$mc_dir/dup/apcdeploy.yml"
+
+step "single-config commands reject multi -c"
+expect_fail "$APCDEPLOY_BIN" status --silent \
+    -c "$mc_dir/dev/apcdeploy.yml" -c "$mc_dir/stg/apcdeploy.yml"

--- a/e2e/cases/s4_deployment_control.sh
+++ b/e2e/cases/s4_deployment_control.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# S4: Deployment control — skip-unchanged, --force, async run.
+
+section "S4" "Deployment control"
+
+step "init + first deploy of staging seed"
+apc_init json-freeform staging
+apc_use_strategy
+apc_write_json '{"t":"1"}'
+apc_quiet run --wait-bake --silent
+
+step "second run with no changes is a no-op"
+# Without --silent so the "skipped (no changes)" Targets line is visible.
+out=$(apc_combined run)
+assert_contains "$out" "no changes" "skip-unchanged"
+
+step "--force re-deploys identical content"
+# --force should bypass the no-change short-circuit; verify by absence of
+# the skip marker in the rendered Targets row.
+out=$(apc_combined run --force --wait-bake)
+assert_not_contains "$out" "no changes" "force ignores no-change"
+
+step "async run (no --wait-*) returns immediately on changed content"
+apc_write_json '{"t":"2"}'
+apc_quiet run --silent

--- a/e2e/cases/s5_config.sh
+++ b/e2e/cases/s5_config.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# S5: Generated config + deployment-strategy verification (yaml profile).
+
+section "S5" "Config generation"
+
+step "init writes region into apcdeploy.yml"
+apc_init yaml-config dev
+assert_grep apcdeploy.yml "region: $REGION"
+
+step "deploy yaml content and verify status"
+apc_use_strategy
+apc_write_yaml 't: 1'
+apc_quiet run --wait-bake --silent
+status_out=$(apc_stdout status --silent)
+assert_contains "$status_out" "COMPLETE" "status"

--- a/e2e/cases/s6_ci.sh
+++ b/e2e/cases/s6_ci.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# S6: CI mode — diff --exit-nonzero detects changes vs deployed state.
+
+section "S6" "CI diff --exit-nonzero"
+
+step "init text profile + write fresh content"
+apc_init text-config dev
+apc_use_strategy
+apc_write_text "$(date)"
+
+step "diff --exit-nonzero exits 1 when local diverges from deployed"
+expect_exit 1 "$APCDEPLOY_BIN" diff --silent --exit-nonzero
+
+step "after run, diff --exit-nonzero exits 0"
+apc_quiet run --wait-bake --timeout 300 --silent
+apc_quiet diff --silent --exit-nonzero

--- a/e2e/cases/s7_rollback.sh
+++ b/e2e/cases/s7_rollback.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# S7: Rollback — start a slow deploy, stop it, observe ROLLED_BACK.
+
+section "S7" "Rollback"
+
+step "start slow deploy on json-freeform/dev"
+apc_init json-freeform dev
+apc_use_strategy "$SLOW_STRATEGY"
+apc_write_json '{"r":"1"}'
+apc_quiet run --silent
+
+step "rollback --yes stops the ongoing deployment"
+apc_quiet rollback --silent --yes
+
+step "status reports ROLLED_BACK"
+status_out=$(apc_stdout status --silent)
+assert_contains "$status_out" "ROLLED_BACK" "status"
+
+step "second rollback with no ongoing deployment fails"
+expect_fail "$APCDEPLOY_BIN" rollback --silent --yes

--- a/e2e/cases/s8_edit.sh
+++ b/e2e/cases/s8_edit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# S8: $EDITOR-driven edit — happy path, no-op, invalid content rejected.
+
+section "S8" "Edit ($EDITOR workflow)"
+
+step "seed deployment with {\"e\":\"seed\"}"
+apc_init json-freeform dev
+apc_use_strategy
+apc_write_json '{"e":"seed"}'
+apc_quiet run --wait-bake --silent
+
+step "edit deploys new content via $EDITOR"
+EDITOR="$FAKE_EDITOR" APCDEPLOY_EDIT_CONTENT='{"e":"new"}' \
+    apc_quiet edit --region "$REGION" --app "$APP" \
+    --profile json-freeform --env dev --wait-bake --silent
+get_out=$(apc_stdout get --silent --yes)
+assert_jq <(printf '%s' "$get_out") '.e == "new"'
+
+step "edit with identical content reports no changes"
+out=$(EDITOR="$FAKE_EDITOR" APCDEPLOY_EDIT_CONTENT='{"e":"new"}' \
+    apc_combined edit --region "$REGION" --app "$APP" \
+    --profile json-freeform --env dev || true)
+assert_contains "$out" "no changes" "edit no-op"
+
+step "edit with invalid JSON is rejected"
+expect_fail env EDITOR="$FAKE_EDITOR" APCDEPLOY_EDIT_CONTENT='not-json' \
+    "$APCDEPLOY_BIN" edit --region "$REGION" --app "$APP" \
+    --profile json-freeform --env dev --silent

--- a/e2e/cases/s9_description.sh
+++ b/e2e/cases/s9_description.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# S9: --description — default marker, explicit, opt-out, length cap, edit.
+
+section "S9" "Description"
+
+step "default --description shows 'Deployed by apcdeploy'"
+apc_init json-freeform dev
+apc_use_strategy
+apc_write_json '{"d":"1"}'
+apc_quiet run --wait-bake --silent
+out=$(apc_combined status)
+assert_contains "$out" "Deployed by apcdeploy" "status description"
+
+step "explicit --description is recorded"
+apc_write_json '{"d":"2"}'
+apc_quiet run --wait-bake --silent --description "explicit run desc"
+out=$(apc_combined status)
+assert_contains "$out" "explicit run desc" "status description"
+
+step "empty --description opts out: no Description row"
+apc_write_json '{"d":"3"}'
+apc_quiet run --wait-bake --silent --description ""
+out=$(apc_combined status)
+refute_line_match "$out" "^Description" "status output"
+
+step "--description >1024 runes is rejected client-side"
+LONG_DESC=$(printf 'a%.0s' {1..1025})
+expect_fail "$APCDEPLOY_BIN" run --silent --description "$LONG_DESC"
+
+step "edit honors --description"
+EDITOR="$FAKE_EDITOR" APCDEPLOY_EDIT_CONTENT='{"d":"edited"}' \
+    apc_quiet edit --region "$REGION" --app "$APP" \
+    --profile json-freeform --env dev --wait-bake --silent \
+    --description "explicit edit desc"
+out=$(apc_combined status)
+assert_contains "$out" "explicit edit desc" "status description"

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -1,286 +1,101 @@
 #!/usr/bin/env bash
-set -eu
+# Entry point for the apcdeploy E2E suite.
+#
+# Usage:
+#   ./e2e-test.sh              # run all sections in order
+#   ./e2e-test.sh S1 S3        # run only the listed sections
+#   E2E_KEEP_TMP=1 ./e2e-test.sh  # don't clean per-section tempdirs (debug)
+#
+# Each section runs in its own tempdir to prevent local-state leakage between
+# sections. AWS-side state coupling (shared profile/env in Terraform) is NOT
+# fixed here — that requires resource-level isolation in terraform/main.tf.
 
-cd "$(dirname "$0")/.."
-go build -o e2e/apcdeploy
+set -euo pipefail
 
-APCDEPLOY="./apcdeploy"
-APP="${E2E_APP:-apcdeploy-e2e-test}"
-REGION="${E2E_REGION:-ap-northeast-1}"
-STRATEGY="E2E-Test-Strategy"
-WORKDIR="./e2e/"
+E2E_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$E2E_DIR/.." && pwd)"
 
-use_strategy() { sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" apcdeploy.yml; }
-use_slow_strategy() { sed -i '' "s/deployment_strategy:.*/deployment_strategy: E2E-Slow-Strategy/" apcdeploy.yml; }
+# Build the binary once at the canonical location used by lib/common.sh.
+cd "$REPO_ROOT"
+go build -o "$E2E_DIR/apcdeploy"
+cd "$E2E_DIR"
 
-# Fake editor used by S8/E3/E5. Reads content from $APCDEPLOY_EDIT_CONTENT
-# rather than embedding it, so callers can vary the bytes safely without
-# re-writing the fixture or worrying about shell-quote escaping.
-FAKE_EDITOR=./edit-fixture.sh
+# shellcheck source=lib/common.sh
+source "$E2E_DIR/lib/common.sh"
+# shellcheck source=lib/assert.sh
+source "$E2E_DIR/lib/assert.sh"
+# shellcheck source=lib/apc.sh
+source "$E2E_DIR/lib/apc.sh"
 
-# test title colored with green
-function title() {
-    echo -e "\e[32m \n##### ${1} #####\n \e[m"
+# Section registry — order is significant (AWS state coupling).
+# S3 must run before S7 / E3 perturb json-freeform/{dev,staging}.
+# Format: <ID>:<case-file-relative-to-cases/>
+SECTIONS=(
+    "S1:s1_workflow.sh"
+    "S2:s2_content_types.sh"
+    "S3:s3_multiconfig.sh"
+    "S4:s4_deployment_control.sh"
+    "S5:s5_config.sh"
+    "S6:s6_ci.sh"
+    "S7:s7_rollback.sh"
+    "S8:s8_edit.sh"
+    "S9:s9_description.sh"
+    "E1:e1_resource_errors.sh"
+    "E2:e2_validation.sh"
+    "E3:e3_constraints.sh"
+    "E4:e4_file_errors.sh"
+    "E5:e5_edge_cases.sh"
+)
+
+# Filter to the IDs passed on the CLI, if any.
+filter_sections() {
+    if [[ $# -eq 0 ]]; then
+        printf '%s\n' "${SECTIONS[@]}"
+        return
+    fi
+    local want=" $* "
+    for entry in "${SECTIONS[@]}"; do
+        local id="${entry%%:*}"
+        if [[ "$want" == *" $id "* ]]; then
+            printf '%s\n' "$entry"
+        fi
+    done
 }
 
-cd "$WORKDIR"
-
-echo "Basic workflow: ls-resources -> init -> diff -> run -> status -> get -> pull -> update -> run"
-title "========== S1: Workflow =========="
-echo "Test ls-resources command"
-# `--silent` without `--json` produces no stdout payload; pair with `--json` for grepping/jq.
-$APCDEPLOY ls-resources --region "$REGION" --json --silent | jq -e --arg app "$APP" '.applications | map(.name) | index($app) != null' > /dev/null
-$APCDEPLOY ls-resources --region "$REGION" --json --silent | jq -e ".region == \"$REGION\"" > /dev/null
-$APCDEPLOY ls-resources --region "$REGION" --json --silent | jq -e '.applications | length > 0' > /dev/null
-$APCDEPLOY ls-resources --region "$REGION" --show-strategies --json --silent | jq -e '.deployment_strategies | map(.name) | index("AppConfig.AllAtOnce") != null' > /dev/null
-$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
-use_strategy
-echo '{"v":"1"}' > data.json
-echo "Test verbose output (without --silent) to verify detailed logging works"
-# diff drives a single Targets row through `comparing` → `✓ <outcome>`.
-# Non-TTY mode emits a line per transition; the exact `<outcome>` (`no
-# changes`, `diff (N lines changed: ...)`, or `no prior deployment`) depends
-# on whether a prior deployment exists and whether local matches it. The
-# test only cares that *some* progress reaches stderr, so we match the
-# Targets transition vocabulary.
-$APCDEPLOY diff 2>&1 | grep -qE "(no changes|no prior deployment|diff \()"
-$APCDEPLOY diff | grep -q "v"
-echo "Test silent mode suppresses verbose output"
-if $APCDEPLOY diff --silent 2>&1 | grep -qE "(no changes|no prior deployment|diff \()"; then
-    echo "ERROR: Silent mode should not show progress messages"
-    exit 1
-fi
-echo "Rest of tests use --silent for cleaner output"
-$APCDEPLOY run --wait-bake --silent
-$APCDEPLOY status --silent | grep -q "COMPLETE"
-$APCDEPLOY get --silent --yes | jq -e '.v == "1"' > /dev/null
-echo "Test pull command: modify local file, then pull to restore deployed state"
-echo '{"v":"modified"}' > data.json
-$APCDEPLOY pull --silent
-jq -e '.v == "1"' data.json > /dev/null
-echo '{"v":"2"}' > data.json
-$APCDEPLOY run --wait-bake --silent
-$APCDEPLOY get --silent --yes | jq -e '.v == "2"' > /dev/null
-
-echo "Support for different content types: FeatureFlags, YAML, text"
-title "========== S2: Content Types =========="
-$APCDEPLOY init --silent --app "$APP" --profile json-featureflags --env dev --region "$REGION" --force
-use_strategy
-echo '{"version":"1","flags":{"test":{"name":"test"}}}' > data.json
-$APCDEPLOY run --wait-bake --silent
-
-$APCDEPLOY init --silent --app "$APP" --profile yaml-config --env dev --region "$REGION" --force
-use_strategy
-sed -i '' 's/data.json/data.yaml/' apcdeploy.yml
-echo -e "v: 1\nk: v" > data.yaml
-$APCDEPLOY run --wait-bake --silent
-
-$APCDEPLOY init --silent --app "$APP" --profile text-config --env dev --region "$REGION" --force
-use_strategy
-sed -i '' 's/data.json/data.txt/' apcdeploy.yml
-echo "text" > data.txt
-$APCDEPLOY run --wait-bake --silent
-
-echo "Multi-config: -c repeated for run/diff/pull"
-title "========== S3: Multi-config =========="
-# Placed right after S2 so the json-freeform/dev + json-freeform/staging
-# pair is exercised before any later section perturbs their AWS state
-# (S7 rollback, E3 in-flight slow deploys, etc.). Build self-contained
-# fixtures under ./multi-config/{dev,stg}/ so the trailing rm in the
-# success path covers them via `rm -rf` below.
-MC_DIR=multi-config
-rm -rf "$MC_DIR"
-mkdir -p "$MC_DIR/dev" "$MC_DIR/stg"
-
-# init populates apcdeploy.yml + (if a prior deployment exists) data.json.
-# We then overwrite the strategy and data so each target deploys fresh
-# content via S3's run; staging starts with no prior deployment on the
-# very first e2e run, in which case init creates only the yml.
-( cd "$MC_DIR/dev" && ../../apcdeploy init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force )
-sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" "$MC_DIR/dev/apcdeploy.yml"
-echo '{"mc":"dev-1"}' > "$MC_DIR/dev/data.json"
-
-( cd "$MC_DIR/stg" && ../../apcdeploy init --silent --app "$APP" --profile json-freeform --env staging --region "$REGION" --force )
-sed -i '' "s/deployment_strategy:.*/deployment_strategy: ${STRATEGY}/" "$MC_DIR/stg/apcdeploy.yml"
-echo '{"mc":"stg-1"}' > "$MC_DIR/stg/data.json"
-
-# Multi-config run deploys both targets in parallel; --wait-bake makes
-# the orchestrator wait until both reach COMPLETE before returning.
-$APCDEPLOY run -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --wait-bake --silent
-$APCDEPLOY get --silent --yes -c "$MC_DIR/dev/apcdeploy.yml" | jq -e '.mc == "dev-1"' > /dev/null
-$APCDEPLOY get --silent --yes -c "$MC_DIR/stg/apcdeploy.yml" | jq -e '.mc == "stg-1"' > /dev/null
-
-# Multi-config diff: both targets report no changes against the deploy
-# we just made. Without --silent the per-target rows show on stderr.
-$APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>&1 | grep -qE "no changes"
-
-# Modify only the dev target's data; the multi-target diff stdout must
-# contain the `=== <id> ===` header for dev only.
-echo '{"mc":"dev-2"}' > "$MC_DIR/dev/data.json"
-diff_out=$($APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" 2>/dev/null || true)
-echo "$diff_out" | grep -q "=== ${REGION}/${APP}/json-freeform/dev ==="
-if echo "$diff_out" | grep -q "=== ${REGION}/${APP}/json-freeform/staging ==="; then
-    echo "ERROR: staging had no changes — its === header should not appear"
+mapfile -t SELECTED < <(filter_sections "$@")
+if [[ ${#SELECTED[@]} -eq 0 ]]; then
+    printf 'No matching sections for: %s\n' "$*" >&2
+    printf 'Available: %s\n' "${SECTIONS[*]%%:*}" >&2
     exit 1
 fi
 
-# Multi-config pull: rewriting the changed local file restores the
-# deployed content, then both files report no changes.
-$APCDEPLOY pull -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --silent
-jq -e '.mc == "dev-1"' "$MC_DIR/dev/data.json" > /dev/null
-jq -e '.mc == "stg-1"' "$MC_DIR/stg/data.json" > /dev/null
-
-# Path-level dedup: the same -c twice must be silently collapsed.
-$APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/dev/apcdeploy.yml" --silent
-# Identifier-level dedup: two distinct paths pointing at the same
-# region/app/profile/env 4-tuple must error before any AWS work.
-mkdir -p "$MC_DIR/dup"
-cp "$MC_DIR/dev/apcdeploy.yml" "$MC_DIR/dup/apcdeploy.yml"
-cp "$MC_DIR/dev/data.json" "$MC_DIR/dup/data.json"
-if $APCDEPLOY diff -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/dup/apcdeploy.yml" --silent; then
-    echo "ERROR: duplicate identifier should have failed"
-    exit 1
-fi
-
-# Single-config commands reject multi -c with a clear error.
-if $APCDEPLOY status -c "$MC_DIR/dev/apcdeploy.yml" -c "$MC_DIR/stg/apcdeploy.yml" --silent 2>/dev/null; then
-    echo "ERROR: status must reject multi -c"
-    exit 1
-fi
-
-rm -rf "$MC_DIR"
-
-echo "Deployment control: skip unchanged, force deploy, async run"
-title "========== S4: Deployment Control =========="
-$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env staging --region "$REGION" --force
-use_strategy
-echo '{"t":"1"}' > data.json
-$APCDEPLOY run --wait-bake --silent
-$APCDEPLOY run --silent
-$APCDEPLOY run --force --wait-bake --silent
-echo '{"t":"2"}' > data.json
-$APCDEPLOY run --silent
-
-echo "Config file generation and deployment strategy verification"
-title "========== S5: Config =========="
-$APCDEPLOY init --silent --app "$APP" --profile yaml-config --env dev --region "$REGION" --force
-grep -q "region: $REGION" apcdeploy.yml
-use_strategy
-sed -i '' 's/data.json/data.yaml/' apcdeploy.yml
-echo "t: 1" > data.yaml
-$APCDEPLOY run --wait-bake --silent
-$APCDEPLOY status --silent | grep -q "COMPLETE"
-
-echo "CI mode: diff --exit-nonzero for detecting changes"
-title "========== S6: CI =========="
-$APCDEPLOY init --silent --app "$APP" --profile text-config --env dev --region "$REGION" --force
-use_strategy
-sed -i '' 's/data.json/data.txt/' apcdeploy.yml
-date > data.txt
-cat data.txt
-if $APCDEPLOY diff --silent --exit-nonzero; then exit 1; fi
-$APCDEPLOY run --wait-bake --timeout 300 --silent
-$APCDEPLOY diff --silent --exit-nonzero
-
-echo "Rollback: stop ongoing deployment with slow strategy"
-title "========== S7: Rollback =========="
-$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
-use_slow_strategy
-echo '{"r":"1"}' > data.json
-$APCDEPLOY run --silent
-$APCDEPLOY rollback --silent --yes
-$APCDEPLOY status --silent | grep -q "ROLLED_BACK"
-if $APCDEPLOY rollback --silent --yes; then exit 1; fi
-
-echo "Edit: $EDITOR-driven workflow (happy, no-op, invalid)"
-title "========== S8: Edit =========="
-$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
-use_strategy
-echo '{"e":"seed"}' > data.json
-$APCDEPLOY run --wait-bake --silent
-
-EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"e":"new"}' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile json-freeform --env dev --wait-bake --silent
-$APCDEPLOY get --silent --yes | jq -e '.e == "new"' > /dev/null
-EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"e":"new"}' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile json-freeform --env dev 2>&1 | grep -q "no changes"
-if EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='not-json' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile json-freeform --env dev --silent; then exit 1; fi
-
-echo "Description: default marker, explicit value, opt-out, length cap, edit"
-title "========== S9: Description =========="
-$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
-use_strategy
-echo '{"d":"1"}' > data.json
-$APCDEPLOY run --wait-bake --silent
-# status renders Description on stderr via Reporter.Table (tab-separated in
-# non-TTY mode) — grep stderr to verify the value is what we expect.
-$APCDEPLOY status 2>&1 | grep -qF "Deployed by apcdeploy"
-echo '{"d":"2"}' > data.json
-$APCDEPLOY run --wait-bake --silent --description "explicit run desc"
-$APCDEPLOY status 2>&1 | grep -qF "explicit run desc"
-echo '{"d":"3"}' > data.json
-$APCDEPLOY run --wait-bake --silent --description ""
-# Empty --description opts out of the default; no Description row should appear.
-if $APCDEPLOY status 2>&1 | grep -q "^Description"; then exit 1; fi
-# >1024 runes is rejected client-side before any AWS round-trip.
-LONG_DESC=$(printf 'a%.0s' {1..1025})
-if $APCDEPLOY run --silent --description "$LONG_DESC"; then exit 1; fi
-EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"d":"edited"}' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile json-freeform --env dev --wait-bake --silent --description "explicit edit desc"
-$APCDEPLOY status 2>&1 | grep -qF "explicit edit desc"
-
-echo "Error handling: non-existent resources (app/profile/env)"
-title "========== E1: Resource Errors =========="
-if $APCDEPLOY init --silent --app xxx --profile test --env dev --region "$REGION"; then exit 1; fi
-if $APCDEPLOY init --silent --app "$APP" --profile xxx --env dev --region "$REGION"; then exit 1; fi
-if $APCDEPLOY init --silent --app "$APP" --profile json-freeform --env xxx --region "$REGION"; then exit 1; fi
-
-echo "Validation errors: invalid JSON syntax"
-title "========== E2: Validation =========="
-$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
-echo '{"bad": json}' > data.json
-if $APCDEPLOY run --silent; then exit 1; fi
-
-echo "Constraint errors: concurrent deployment, timeout, edit while ongoing"
-title "========== E3: Constraints =========="
-$APCDEPLOY init --silent --app "$APP" --profile error-test --env dev --region "$REGION" --force
-use_slow_strategy
-echo '{"c":"1"}' > data.json
-$APCDEPLOY run --silent >/dev/null 2>&1 &
-sleep 2
-if $APCDEPLOY run --silent; then exit 1; fi
-if EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"c":"x"}' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile error-test --env dev --silent; then exit 1; fi
-wait || true
-
-echo '{"c":"2"}' > data.json
-if $APCDEPLOY run --wait-bake --timeout 5 --silent; then exit 1; fi
-
-echo "File errors: missing config, invalid config, file exists"
-title "========== E4: File Errors =========="
-if $APCDEPLOY run --config xxx.yml --silent; then exit 1; fi
-
-$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
-sed -i '' '/application:/d' apcdeploy.yml
-if $APCDEPLOY run --silent; then exit 1; fi
-
-$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
-if $APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION"; then exit 1; fi
-$APCDEPLOY init --silent --app "$APP" --profile json-freeform --env dev --region "$REGION" --force
-
-echo "Edge cases: no deployment history, invalid timeout, missing required flags, exit-code 2 sentinel"
-title "========== E5: Edge Cases =========="
-$APCDEPLOY init --silent --app "$APP" --profile error-test --env staging --region "$REGION" --force
-use_strategy
-# Run without `--silent` because the "no deployment" notice is now part of
-# the Targets row's terminal state ("✓ no prior deployment" for diff,
-# "→ no deployment" for status) — silent mode suppresses Targets entirely
-# (only Error / Data / Diff survive).
-$APCDEPLOY diff 2>&1 | grep -q "no prior deployment" || echo "⚠️  Deployment may exist"
-$APCDEPLOY status 2>&1 | grep -q "no deployment" || echo "⚠️  Deployment may exist"
-
-# pull and edit must exit 2 (not 1) so scripts can distinguish "no prior deployment" from real errors.
-rc=0; $APCDEPLOY pull --silent || rc=$?; [ "$rc" -eq 2 ]
-rc=0; EDITOR=$FAKE_EDITOR APCDEPLOY_EDIT_CONTENT='{"e":"x"}' $APCDEPLOY edit --region "$REGION" --app "$APP" --profile error-test --env staging --silent || rc=$?; [ "$rc" -eq 2 ]
-
-echo '{"e":"1"}' > data.json
-if $APCDEPLOY run --wait-bake --timeout -1 --silent; then exit 1; fi
-
-rm data.txt data.yaml data.json apcdeploy.yml apcdeploy
-echo "✅ All tests passed"
+# Run each case in its own tempdir + subshell so failures don't leak state
+# into the next section. The subshell also re-exports the ERR/EXIT traps
+# (bash inherits ERR via `set -E`, EXIT is per-shell).
+#
+# Per-section tempdirs are tracked in TMPDIRS and cleaned up by common.sh's
+# __on_exit — registering a `trap "rm -rf …" EXIT` per iteration would
+# overwrite (not chain) the parent EXIT trap and disable the final summary.
+set -E
+TMPDIRS=()
+export TMPDIRS
+for entry in "${SELECTED[@]}"; do
+    id="${entry%%:*}"
+    file="${entry#*:}"
+    case_path="$E2E_DIR/cases/$file"
+    if [[ ! -f "$case_path" ]]; then
+        printf 'Missing case file: %s\n' "$case_path" >&2
+        exit 1
+    fi
+    tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/apcdeploy-e2e-${id}.XXXXXX")"
+    TMPDIRS+=("$tmpdir")
+    (
+        cd "$tmpdir"
+        # Finalize the last step on subshell exit so its ✓ is printed
+        # (subshell variables don't propagate, so the parent's __on_exit
+        # cannot see the section's trailing step).
+        trap '__finalize_step ok' EXIT
+        # shellcheck source=/dev/null
+        source "$case_path"
+    )
+done

--- a/e2e/e2e-test.sh
+++ b/e2e/e2e-test.sh
@@ -77,8 +77,9 @@ fi
 # __on_exit — registering a `trap "rm -rf …" EXIT` per iteration would
 # overwrite (not chain) the parent EXIT trap and disable the final summary.
 set -E
+# Visible to common.sh's __on_exit (same shell) without export — bash does
+# not export arrays through the environment anyway.
 TMPDIRS=()
-export TMPDIRS
 for entry in "${SELECTED[@]}"; do
     id="${entry%%:*}"
     file="${entry#*:}"

--- a/e2e/lib/apc.sh
+++ b/e2e/lib/apc.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Sourced only — inherits e2e-test.sh's set -euo pipefail.
+# apcdeploy CLI wrappers + fixture helpers.
+# All wrappers redirect the binary's stderr into $__STDERR_FILE (defined in
+# common.sh) so the ERR trap can show the last 10 lines on failure. Each
+# wrapper truncates that file on entry so the displayed context is from the
+# most recent call only — important because `$(apc_quiet …)` runs in a
+# subshell whose local variables are invisible to the parent's trap.
+
+# Run apcdeploy with stderr captured (suppressed unless the call fails).
+# Use both as a bare command (`apc_quiet run …`) and inside command
+# substitution (`out=$(apc_quiet get …)`).
+apc_quiet() {
+    : > "$__STDERR_FILE"
+    "$APCDEPLOY_BIN" "$@" 2>"$__STDERR_FILE"
+}
+
+# Alias retained for readability at call sites that want to signal
+# "I'm capturing stdout here" — implementation is intentionally identical
+# to apc_quiet.
+apc_stdout() {
+    apc_quiet "$@"
+}
+
+# Merged stdout+stderr — used for assertions on combined output (e.g.
+# status's tab-separated rows live on stderr but we want one capture).
+# NOTE: stderr is merged into stdout, so $__STDERR_FILE is NOT updated on
+# failure here; the ERR trap's "last stderr" section will show data from
+# an earlier apc_quiet call instead. Use apc_quiet when you need both
+# stdout capture and useful failure diagnostics.
+apc_combined() {
+    "$APCDEPLOY_BIN" "$@" 2>&1
+}
+
+# ---- High-level fixture helpers ------------------------------------------
+
+# apc_init <profile> <env> [extra args...]
+# Runs `apcdeploy init --silent --force` against the test app/region.
+apc_init() {
+    local profile="$1" env="$2"; shift 2
+    apc_quiet init --silent --force \
+        --app "$APP" --region "$REGION" \
+        --profile "$profile" --env "$env" "$@"
+}
+
+# apc_use_strategy [strategy_name]
+# Patches deployment_strategy in apcdeploy.yml. Defaults to $STRATEGY.
+# Uses portable sed (the BSD/GNU difference is hidden behind a temp file move).
+apc_use_strategy() {
+    local strategy="${1:-$STRATEGY}"
+    local tmp; tmp="$(mktemp)"
+    sed "s/deployment_strategy:.*/deployment_strategy: ${strategy}/" \
+        apcdeploy.yml > "$tmp"
+    mv "$tmp" apcdeploy.yml
+}
+
+# Internal: patch data_file in apcdeploy.yml (used when changing extension).
+__apc_set_data_file() {
+    local file="$1"
+    local tmp; tmp="$(mktemp)"
+    sed "s|data_file:.*|data_file: ${file}|" apcdeploy.yml > "$tmp"
+    mv "$tmp" apcdeploy.yml
+}
+
+# apc_remove_field <field>
+# Strips a top-level field from apcdeploy.yml (used for E4 invalid-config tests).
+apc_remove_field() {
+    local field="$1"
+    local tmp; tmp="$(mktemp)"
+    sed "/^${field}:/d" apcdeploy.yml > "$tmp"
+    mv "$tmp" apcdeploy.yml
+}
+
+# apc_write_data <content> [filename]
+# Writes the data file. Default filename is data.json (matches `init` output).
+apc_write_data() {
+    local content="$1" file="${2:-data.json}"
+    printf '%s' "$content" > "$file"
+}
+
+# Convenience: write JSON / YAML / text + sync data_file in apcdeploy.yml.
+apc_write_json() {
+    local content="$1"
+    apc_write_data "$content" data.json
+}
+
+apc_write_yaml() {
+    local content="$1"
+    __apc_set_data_file data.yaml
+    apc_write_data "$content" data.yaml
+}
+
+apc_write_text() {
+    local content="$1"
+    __apc_set_data_file data.txt
+    apc_write_data "$content" data.txt
+}

--- a/e2e/lib/assert.sh
+++ b/e2e/lib/assert.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Sourced only — inherits e2e-test.sh's set -euo pipefail.
+# Assertions used by case scripts. Each assertion calls `fail` (from common.sh)
+# on mismatch, which prints the current step as ✗ with a structured message
+# and exits 1 — keeping stack traces consistent across the suite.
+
+# assert_contains <haystack> <needle> [label]
+assert_contains() {
+    local haystack="$1" needle="$2" label="${3:-output}"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        fail "$label missing substring <$needle>: <$haystack>"
+    fi
+}
+
+# assert_not_contains <haystack> <needle> [label]
+assert_not_contains() {
+    local haystack="$1" needle="$2" label="${3:-output}"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        fail "$label unexpectedly contains <$needle>: <$haystack>"
+    fi
+}
+
+# assert_match <haystack> <regex> [label] — extended regex via bash =~
+assert_match() {
+    local haystack="$1" regex="$2" label="${3:-output}"
+    if ! [[ "$haystack" =~ $regex ]]; then
+        fail "$label did not match /$regex/: <$haystack>"
+    fi
+}
+
+# assert_jq <file_or_-> <jq_expression>
+# Asserts the expression evaluates truthy. `-` reads stdin; otherwise the
+# first arg is treated as a file path (also accepts process substitution
+# like `<(printf '%s' "$out")`).
+assert_jq() {
+    local src="$1" expr="$2"
+    if [[ "$src" == "-" ]]; then
+        if ! jq -e "$expr" >/dev/null; then
+            fail "jq predicate failed: <$expr> (stdin)"
+        fi
+    else
+        if ! jq -e "$expr" "$src" >/dev/null; then
+            fail "jq predicate failed: <$expr> ($src)"
+        fi
+    fi
+}
+
+# expect_fail <command...>
+# Inverts the exit code: passes only when the command fails (any non-zero).
+# Suppresses ERR trap because the failure is expected.
+expect_fail() {
+    if "$@" >/dev/null 2>&1; then
+        fail "command unexpectedly succeeded: $*"
+    fi
+}
+
+# expect_exit <expected_code> <command...>
+# Asserts the command exits with exactly <expected_code>.
+expect_exit() {
+    local expected="$1"; shift
+    local rc=0
+    "$@" >/dev/null 2>&1 || rc=$?
+    if [[ "$rc" -ne "$expected" ]]; then
+        fail "expected exit $expected, got $rc: $*"
+    fi
+}
+
+# assert_grep <file> <pattern>
+assert_grep() {
+    local file="$1" pattern="$2"
+    if ! grep -qE "$pattern" "$file"; then
+        fail "pattern /$pattern/ not found in $file"
+    fi
+}
+
+# refute_line_match <haystack> <extended_regex> [label]
+# Asserts that no line of <haystack> matches the extended regex. Used for
+# anchored patterns like "^Description" where assert_not_contains is too
+# loose (would miss a match at the very first line).
+refute_line_match() {
+    local haystack="$1" regex="$2" label="${3:-output}"
+    if printf '%s' "$haystack" | grep -qE "$regex"; then
+        fail "$label unexpectedly matched /$regex/"
+    fi
+}

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -110,6 +110,9 @@ __on_err() {
         printf '  %s✗%s %s\n' "$C_RED" "$C_RESET" "$__STEP" >&2
         printf '    %sat %s:%s (exit %d)%s\n' \
             "$C_DIM" "${source#"$E2E_ROOT/"}" "$lineno" "$rc" "$C_RESET" >&2
+        # Mark already-reported so the subshell's EXIT trap doesn't
+        # re-finalize this step as ✓ (and double-count it in __STEPS_FILE).
+        __STEP=""
     fi
     if [[ -n "${__STDERR_FILE:-}" && -s "$__STDERR_FILE" ]]; then
         printf '    %s---- last stderr ----%s\n' "$C_DIM" "$C_RESET" >&2

--- a/e2e/lib/common.sh
+++ b/e2e/lib/common.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Shared environment, output helpers, and ERR/EXIT traps for e2e tests.
+# Sourced only by e2e-test.sh — do not `set -e` here; inherits the runner's
+# `set -euo pipefail`. Sourced before any case file runs.
+
+# ---- Global env -----------------------------------------------------------
+
+E2E_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APCDEPLOY_BIN="${APCDEPLOY_BIN:-$E2E_ROOT/apcdeploy}"
+FAKE_EDITOR="${FAKE_EDITOR:-$E2E_ROOT/edit-fixture.sh}"
+APP="${E2E_APP:-apcdeploy-e2e-test}"
+REGION="${E2E_REGION:-ap-northeast-1}"
+STRATEGY="${E2E_STRATEGY:-E2E-Test-Strategy}"
+SLOW_STRATEGY="${E2E_SLOW_STRATEGY:-E2E-Slow-Strategy}"
+
+export E2E_ROOT APCDEPLOY_BIN FAKE_EDITOR APP REGION STRATEGY SLOW_STRATEGY
+
+# ---- Color (NO_COLOR + TTY aware) ----------------------------------------
+
+# shellcheck disable=SC2034  # palette intentionally complete; C_YELLOW reserved for future Warn-equivalent output
+if [[ -t 2 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    C_RESET=$'\033[0m'
+    C_RED=$'\033[31m'
+    C_GREEN=$'\033[32m'
+    C_YELLOW=$'\033[33m'
+    C_BLUE=$'\033[34m'
+    C_DIM=$'\033[2m'
+    C_BOLD=$'\033[1m'
+else
+    C_RESET="" C_RED="" C_GREEN="" C_YELLOW="" C_BLUE="" C_DIM="" C_BOLD=""
+fi
+
+# ---- Section / step state ------------------------------------------------
+
+__SECTION_ID=""
+__STEP=""
+__START_TIME=$(date +%s)
+
+# Single shared file every apc_* wrapper redirects stderr into. Using a
+# fixed path (vs per-call mktemp) is required because wrappers may run in
+# $(...) subshells, where any locally-assigned variable is lost when the
+# subshell exits — leaving the parent's ERR trap with no way to find the
+# capture file. The file is reused across calls; each wrapper truncates it
+# on entry so only the most recent command's stderr is shown on failure.
+__STDERR_FILE="${TMPDIR:-/tmp}/apcdeploy-e2e-stderr.$$"
+: > "$__STDERR_FILE"
+export __STDERR_FILE
+
+# Shared step / section counters. Each subshell-per-section finalizes a
+# step by appending a line to __STEPS_FILE, and `section()` appends to
+# __SECTIONS_FILE; the parent shell's EXIT trap reads the line counts for
+# the final summary. Files are needed because per-section subshells can't
+# write back into the parent's variables.
+__STEPS_FILE="${TMPDIR:-/tmp}/apcdeploy-e2e-steps.$$"
+: > "$__STEPS_FILE"
+__SECTIONS_FILE="${TMPDIR:-/tmp}/apcdeploy-e2e-sections.$$"
+: > "$__SECTIONS_FILE"
+export __STEPS_FILE __SECTIONS_FILE
+
+# Print the canonical section header. Closes the previous step (if any).
+section() {
+    __finalize_step ok
+    __SECTION_ID="$1"
+    local title="$2"
+    echo 1 >> "$__SECTIONS_FILE"
+    local rule="══════════════════════════════════════════════════════════════"
+    {
+        printf '\n%s%s%s\n' "$C_BLUE" "$rule" "$C_RESET"
+        printf ' %s%s%s  %s%s%s\n' "$C_BOLD" "$__SECTION_ID" "$C_RESET" "$C_BOLD" "$title" "$C_RESET"
+        printf '%s%s%s\n' "$C_BLUE" "$rule" "$C_RESET"
+    } >&2
+}
+
+# Open a new step. The previous step (if any) is finalized as ✓.
+# A failing command between `step` calls trips ERR trap, which finalizes ✗.
+step() {
+    __finalize_step ok
+    __STEP="$1"
+}
+
+__finalize_step() {
+    local result="$1"  # ok|fail
+    [[ -z "$__STEP" ]] && return 0
+    if [[ "$result" == "ok" ]]; then
+        printf '  %s✓%s %s\n' "$C_GREEN" "$C_RESET" "$__STEP" >&2
+        # Append to shared file so the parent shell's __on_exit can count
+        # steps from per-section subshells.
+        echo 1 >> "$__STEPS_FILE"
+    fi
+    __STEP=""
+}
+
+# Hard fail with a custom message (used by assertions).
+fail() {
+    local msg="$1"
+    if [[ -n "$__STEP" ]]; then
+        printf '  %s✗%s %s\n' "$C_RED" "$C_RESET" "$__STEP" >&2
+    fi
+    printf '    %s%s%s\n' "$C_RED" "$msg" "$C_RESET" >&2
+    __STEP=""  # already reported
+    exit 1
+}
+
+# ERR trap: print the current step as failed with file:line context.
+__on_err() {
+    local rc=$?
+    local lineno="$1"
+    local source="$2"
+    if [[ -n "$__STEP" ]]; then
+        printf '  %s✗%s %s\n' "$C_RED" "$C_RESET" "$__STEP" >&2
+        printf '    %sat %s:%s (exit %d)%s\n' \
+            "$C_DIM" "${source#"$E2E_ROOT/"}" "$lineno" "$rc" "$C_RESET" >&2
+    fi
+    if [[ -n "${__STDERR_FILE:-}" && -s "$__STDERR_FILE" ]]; then
+        printf '    %s---- last stderr ----%s\n' "$C_DIM" "$C_RESET" >&2
+        tail -n 10 "$__STDERR_FILE" | sed 's/^/    /' >&2
+    fi
+}
+
+# EXIT trap: emit the final summary on clean exit; cleanup is left to subshells.
+__on_exit() {
+    local rc=$?
+    if [[ $rc -eq 0 ]]; then
+        __finalize_step ok
+        local total_steps=0
+        local total_sections=0
+        if [[ -f "$__STEPS_FILE" ]]; then
+            total_steps=$(wc -l < "$__STEPS_FILE" | tr -d ' ')
+        fi
+        if [[ -f "$__SECTIONS_FILE" ]]; then
+            total_sections=$(wc -l < "$__SECTIONS_FILE" | tr -d ' ')
+        fi
+        local elapsed=$(( $(date +%s) - __START_TIME ))
+        local mins=$((elapsed / 60))
+        local secs=$((elapsed % 60))
+        local rule="──────────────────────────────────────────────────────────────"
+        {
+            printf '\n%s%s%s\n' "$C_DIM" "$rule" "$C_RESET"
+            printf ' %s✓%s %d sections, %d steps passed (%dm %ds)\n' \
+                "$C_GREEN" "$C_RESET" "$total_sections" "$total_steps" "$mins" "$secs"
+            printf '%s%s%s\n' "$C_DIM" "$rule" "$C_RESET"
+        } >&2
+    fi
+    [[ -n "${__STDERR_FILE:-}" ]] && rm -f "$__STDERR_FILE"
+    [[ -n "${__STEPS_FILE:-}" ]] && rm -f "$__STEPS_FILE"
+    [[ -n "${__SECTIONS_FILE:-}" ]] && rm -f "$__SECTIONS_FILE"
+    # Clean up per-section tempdirs registered by e2e-test.sh.
+    # `${arr[@]:-default}` is not valid for arrays in bash; gate on
+    # existence (`${TMPDIRS+x}`) before reading the length.
+    if [[ -z "${E2E_KEEP_TMP:-}" && -n "${TMPDIRS+x}" && ${#TMPDIRS[@]} -gt 0 ]]; then
+        rm -rf "${TMPDIRS[@]}"
+    fi
+}
+
+trap '__on_err $LINENO "${BASH_SOURCE[0]}"' ERR
+trap '__on_exit' EXIT


### PR DESCRIPTION
## Summary

- Reduce `e2e/e2e-test.sh` from a 362-line monolith to a thin orchestrator. Per-scenario logic moves into `e2e/cases/` (S1–S9 success, E1–E5 errors); shared helpers live in `e2e/lib/` (`common.sh`, `assert.sh`, `apc.sh`). Run a subset with `./e2e/e2e-test.sh S1 S3`; keep tempdirs for debugging via `E2E_KEEP_TMP=1`.
- Fix `EXIT` trap overwrite in the runner — the previous loop registered `trap "rm -rf '$tmpdir'" EXIT` per iteration, replacing `__on_exit` and disabling both the final summary and cleanup of all but the last tempdir. Tempdirs are now tracked in `TMPDIRS` and reaped by `__on_exit`.
- Replace hollow exit-code-only checks in S2 (FeatureFlags / YAML / Text) and S4 (skip-unchanged / `--force`) with real round-trip / effect assertions. FeatureFlags uses `pull` because the AppConfig Data API returns evaluated flag values, not the raw flags definition.
- Harden E3: poll `status` for `DEPLOYING` instead of `sleep 2` (eliminates a CI flake), and add a cleanup trap that kills the background process and rolls back the AWS deployment if a later step short-circuits via `set -e`.
- Drop dead helpers (`apc()`, `assert_eq`, `assert_file_jq`), unify `apc_stdout`/`apc_quiet`, and document the new structure in `CLAUDE.md`.

## Test plan

- [x] `mise run e2e-full` — 14 sections, 65 steps passed (52s)
- [x] `bash -n` and `shellcheck -x` clean across runner / lib / cases
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)