### PR TITLE
docs(status): document exit code 2 for no-deployment case

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ Options:
 
 - `--deployment`: Deployment number to check (defaults to latest)
 
+Exits with code 2 when no deployment exists for the profile + environment.
+
 ### get
 
 Retrieve the currently deployed configuration:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,7 @@ import (
 const (
 	// exitNoDeployment is returned for the "no relevant deployment to operate
 	// on" family of errors:
-	//   - awsInternal.ErrNoDeployment (pull / edit: never been deployed)
+	//   - awsInternal.ErrNoDeployment (pull / edit / status: never been deployed)
 	//   - rollback.ErrNoOngoingDeployment (rollback: nothing in flight to stop)
 	// Scripts can use this code to branch on "no work to do" without parsing
 	// stderr.

--- a/llms.md
+++ b/llms.md
@@ -446,12 +446,13 @@ State values:
 
 | Cause | Resolution |
 |---|---|
-| No deployment has ever been made for the profile + environment | Run `apcdeploy run -c apcdeploy.yml` first to create the initial deployment, then `status` will have something to report. |
+| No deployment has ever been made for the profile + environment (exit code `2`) | Run `apcdeploy run -c apcdeploy.yml` first to create the initial deployment, then `status` will have something to report. |
 
 #### Exit Codes
 
 - `0`: success
-- `1`: AWS error, or no deployment exists for the profile + environment
+- `1`: AWS error
+- `2`: no deployment exists for the profile + environment
 
 #### Examples
 


### PR DESCRIPTION
## Summary

- `status` already returns `aws.ErrNoDeployment` (`internal/status/executor.go:95`) for the "no deployment" case, which `cmd/root.go`'s classifier maps to exit 2 — matching the design intent in `docs/design/output.md` §8.6.
- The user-facing docs (`README.md`, `llms.md`) and the in-source classifier comment (`cmd/root.go`) listed only `pull` / `edit` / `rollback` for exit 2, missing `status`.
- This PR fixes the doc/comment drift only — no behavioral change.

## Changes

- `llms.md`: status Errors row gains `(exit code 2)`; Exit Codes split into `0` / `1` / `2`.
- `README.md`: status section gets a one-liner matching `pull` / `edit` / `rollback` style.
- `cmd/root.go`: `exitNoDeployment` comment now lists `status` alongside `pull` / `edit`.

## Test plan

- [x] `mise run ci` (fmt, fix, lint-fix, build, cov) — all pass, coverage 91.2%.
- [x] No code changes; existing `TestExecutorNoDeployment` (status) and `TestClassifyAndReport` already cover the exit-2 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)