### PR TITLE
fix(aws): paginate account.ListRegions to avoid silent region truncation

### DIFF
--- a/internal/aws/region.go
+++ b/internal/aws/region.go
@@ -9,32 +9,42 @@ import (
 	accountTypes "github.com/aws/aws-sdk-go-v2/service/account/types"
 )
 
-// ListEnabledRegions returns a sorted list of enabled regions for the account
+// ListEnabledRegions returns a sorted list of enabled regions for the account.
+// It paginates through all pages of account.ListRegions to avoid silently truncating
+// accounts whose enabled-region list spans multiple pages.
 func ListEnabledRegions(ctx context.Context, client AccountAPI) ([]string, error) {
-	input := &account.ListRegionsInput{
-		RegionOptStatusContains: []accountTypes.RegionOptStatus{
-			accountTypes.RegionOptStatusEnabled,
-			accountTypes.RegionOptStatusEnabledByDefault,
-		},
-	}
+	var regions []string
+	var nextToken *string
 
-	output, err := client.ListRegions(ctx, input)
-	if err != nil {
-		return nil, err
-	}
+	for {
+		output, err := client.ListRegions(ctx, &account.ListRegionsInput{
+			RegionOptStatusContains: []accountTypes.RegionOptStatus{
+				accountTypes.RegionOptStatusEnabled,
+				accountTypes.RegionOptStatusEnabledByDefault,
+			},
+			NextToken: nextToken,
+		})
+		if err != nil {
+			return nil, err
+		}
 
-	regions := make([]string, 0, len(output.Regions))
-	for _, region := range output.Regions {
-		// Skip regions with nil names
-		if region.RegionName == nil {
-			continue
+		for _, region := range output.Regions {
+			// Skip regions with nil names
+			if region.RegionName == nil {
+				continue
+			}
+			// Defensive check: only include enabled or enabled by default regions
+			// (API should filter, but this is a safety measure)
+			if region.RegionOptStatus == accountTypes.RegionOptStatusEnabled ||
+				region.RegionOptStatus == accountTypes.RegionOptStatusEnabledByDefault {
+				regions = append(regions, aws.ToString(region.RegionName))
+			}
 		}
-		// Defensive check: only include enabled or enabled by default regions
-		// (API should filter, but this is a safety measure)
-		if region.RegionOptStatus == accountTypes.RegionOptStatusEnabled ||
-			region.RegionOptStatus == accountTypes.RegionOptStatusEnabledByDefault {
-			regions = append(regions, aws.ToString(region.RegionName))
+
+		if output.NextToken == nil {
+			break
 		}
+		nextToken = output.NextToken
 	}
 
 	slices.Sort(regions)

--- a/internal/aws/region_test.go
+++ b/internal/aws/region_test.go
@@ -130,6 +130,118 @@ func TestListEnabledRegions(t *testing.T) {
 	}
 }
 
+func TestListEnabledRegions_MultiPage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		setupMock   func() *mock.MockAccountClient
+		wantRegions []string
+		wantErr     bool
+	}{
+		{
+			name: "two pages are combined and sorted",
+			setupMock: func() *mock.MockAccountClient {
+				callCount := 0
+				return &mock.MockAccountClient{
+					ListRegionsFunc: func(ctx context.Context, params *account.ListRegionsInput, optFns ...func(*account.Options)) (*account.ListRegionsOutput, error) {
+						callCount++
+						if callCount == 1 {
+							return &account.ListRegionsOutput{
+								Regions: []accountTypes.Region{
+									{RegionName: aws.String("us-west-2"), RegionOptStatus: accountTypes.RegionOptStatusEnabled},
+									{RegionName: aws.String("eu-west-1"), RegionOptStatus: accountTypes.RegionOptStatusEnabledByDefault},
+								},
+								NextToken: aws.String("page2"),
+							}, nil
+						}
+						return &account.ListRegionsOutput{
+							Regions: []accountTypes.Region{
+								{RegionName: aws.String("ap-northeast-1"), RegionOptStatus: accountTypes.RegionOptStatusEnabled},
+								{RegionName: aws.String("us-east-1"), RegionOptStatus: accountTypes.RegionOptStatusEnabledByDefault},
+							},
+						}, nil
+					},
+				}
+			},
+			wantRegions: []string{"ap-northeast-1", "eu-west-1", "us-east-1", "us-west-2"},
+		},
+		{
+			name: "three pages are combined and sorted",
+			setupMock: func() *mock.MockAccountClient {
+				callCount := 0
+				return &mock.MockAccountClient{
+					ListRegionsFunc: func(ctx context.Context, params *account.ListRegionsInput, optFns ...func(*account.Options)) (*account.ListRegionsOutput, error) {
+						callCount++
+						switch callCount {
+						case 1:
+							return &account.ListRegionsOutput{
+								Regions: []accountTypes.Region{
+									{RegionName: aws.String("us-west-2"), RegionOptStatus: accountTypes.RegionOptStatusEnabled},
+								},
+								NextToken: aws.String("page2"),
+							}, nil
+						case 2:
+							return &account.ListRegionsOutput{
+								Regions: []accountTypes.Region{
+									{RegionName: aws.String("eu-west-1"), RegionOptStatus: accountTypes.RegionOptStatusEnabled},
+								},
+								NextToken: aws.String("page3"),
+							}, nil
+						default:
+							return &account.ListRegionsOutput{
+								Regions: []accountTypes.Region{
+									{RegionName: aws.String("ap-southeast-1"), RegionOptStatus: accountTypes.RegionOptStatusEnabledByDefault},
+								},
+							}, nil
+						}
+					},
+				}
+			},
+			wantRegions: []string{"ap-southeast-1", "eu-west-1", "us-west-2"},
+		},
+		{
+			name: "second page API error is returned",
+			setupMock: func() *mock.MockAccountClient {
+				callCount := 0
+				return &mock.MockAccountClient{
+					ListRegionsFunc: func(ctx context.Context, params *account.ListRegionsInput, optFns ...func(*account.Options)) (*account.ListRegionsOutput, error) {
+						callCount++
+						if callCount == 1 {
+							return &account.ListRegionsOutput{
+								Regions: []accountTypes.Region{
+									{RegionName: aws.String("us-east-1"), RegionOptStatus: accountTypes.RegionOptStatusEnabled},
+								},
+								NextToken: aws.String("page2"),
+							}, nil
+						}
+						return nil, errors.New("page 2 API error")
+					},
+				}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			mockClient := tt.setupMock()
+
+			regions, err := awsInternal.ListEnabledRegions(ctx, mockClient)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRegions, regions)
+		})
+	}
+}
+
 func TestListEnabledRegions_RequestsCorrectFilter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `ListEnabledRegions` in `internal/aws/region.go` issued a single `account.ListRegions` call and never followed `NextToken`, silently dropping enabled regions when the list spans multiple pages.
- Fixed by adding the same `NextToken` loop pattern used by all `ListAll*` AppConfig helpers in `client_list_paginated.go`.

## What changed

- `internal/aws/region.go`: Replaced the single `client.ListRegions` call with a `for` loop that follows `NextToken` until the final page, accumulating regions across all pages before sorting.
- `internal/aws/region_test.go`: Added `TestListEnabledRegions_MultiPage` with three table-driven cases:
  - two pages combined and sorted correctly
  - three pages combined and sorted correctly
  - error on the second page is propagated

## How tested

- New failing tests confirmed the bug before the fix.
- All existing `TestListEnabledRegions` cases continue to pass.
- `mise run ci` passes (fmt, fix, lint-fix, build, coverage).

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)