### PR TITLE
fix(config): preserve large integer precision in formatJSON

### DIFF
--- a/internal/config/generator.go
+++ b/internal/config/generator.go
@@ -110,11 +110,15 @@ func WriteDataFile(content []byte, contentType, outputPath, profileType string, 
 	return nil
 }
 
-// formatJSON formats JSON data with proper indentation
-// For FeatureFlags profile type, it removes _updatedAt and _createdAt fields recursively
+// formatJSON formats JSON data with proper indentation.
+// For FeatureFlags profile type, it removes _updatedAt and _createdAt fields recursively.
+// UseNumber is used during decoding so that large integers (> 2^53) are preserved
+// exactly instead of being converted to float64, which would cause precision loss.
 func formatJSON(data []byte, profileType string) ([]byte, error) {
 	var obj any
-	if err := json.Unmarshal(data, &obj); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&obj); err != nil {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 

--- a/internal/config/generator_test.go
+++ b/internal/config/generator_test.go
@@ -487,6 +487,20 @@ func Test_formatJSON(t *testing.T) {
 			input:   []byte(`{invalid`),
 			wantErr: true,
 		},
+		{
+			// Integers > 2^53 cannot be represented exactly as float64.
+			// formatJSON must preserve them without precision loss.
+			name:    "large integer preserves precision",
+			input:   []byte(`{"id":9007199254740993}`),
+			want:    "{\n  \"id\": 9007199254740993\n}\n",
+			wantErr: false,
+		},
+		{
+			name:    "multiple large integers preserve precision",
+			input:   []byte(`{"a":9007199254740993,"b":9007199254740994}`),
+			want:    "{\n  \"a\": 9007199254740993,\n  \"b\": 9007199254740994\n}\n",
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- `formatJSON` decoded JSON into `any` via `json.Unmarshal`, which stores all numbers as `float64`. Integers larger than 2^53 cannot be represented exactly in `float64`, causing silent precision loss when `pull`/`init` rewrite the local data file.
- The lossy file is then sent by `run` to `CreateHostedConfigurationVersion`, silently altering the deployed config value.

## What changed

Replaced `json.Unmarshal(data, &obj)` with a `json.Decoder` that calls `UseNumber()` before decoding. This causes JSON integers to be stored as `json.Number` (a string-backed type) rather than `float64`, so the value round-trips exactly through the encoder. All other formatting behaviour (indentation, FeatureFlags timestamp stripping) is unchanged.

**File changed:** `internal/config/generator.go` — `formatJSON` function (lines 115–134)

## How tested

Two new table-driven test cases were added to `Test_formatJSON` in `internal/config/generator_test.go`:

- `large integer preserves precision` — `{"id":9007199254740993}` must round-trip to the identical value (not `9007199254740992` as the float64 path produces)
- `multiple large integers preserve precision` — two large integers in the same object must both survive unchanged

Both tests failed before the fix and pass after it. `mise run ci` passes with 91.3% coverage (no regression).

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)