### PR TITLE
fix(aws): detect VALIDATING/ROLLING_BACK as ongoing deployments

### DIFF
--- a/internal/aws/deployment.go
+++ b/internal/aws/deployment.go
@@ -18,13 +18,17 @@ func (c *Client) CheckOngoingDeployment(ctx context.Context, applicationID, envi
 		return false, nil, wrapAWSError(err, "failed to list deployments")
 	}
 
-	// Check for ongoing deployments (any in-flight state)
+	// Check for ongoing (in-flight) deployments. The transitional states
+	// are DEPLOYING, BAKING, VALIDATING and ROLLING_BACK. The terminal
+	// states COMPLETE, ROLLED_BACK and REVERTED are deliberately excluded:
+	// they persist in the deployment history indefinitely, so treating one
+	// as "ongoing" would permanently block run/edit (false "already in
+	// progress") and make rollback try to stop a finished deployment.
 	for _, deployment := range deployments {
 		if deployment.State == types.DeploymentStateDeploying ||
 			deployment.State == types.DeploymentStateBaking ||
 			deployment.State == types.DeploymentStateValidating ||
-			deployment.State == types.DeploymentStateRollingBack ||
-			deployment.State == types.DeploymentStateReverted {
+			deployment.State == types.DeploymentStateRollingBack {
 			return true, &deployment, nil
 		}
 	}

--- a/internal/aws/deployment.go
+++ b/internal/aws/deployment.go
@@ -18,10 +18,13 @@ func (c *Client) CheckOngoingDeployment(ctx context.Context, applicationID, envi
 		return false, nil, wrapAWSError(err, "failed to list deployments")
 	}
 
-	// Check for ongoing deployments (DEPLOYING or BAKING state)
+	// Check for ongoing deployments (any in-flight state)
 	for _, deployment := range deployments {
 		if deployment.State == types.DeploymentStateDeploying ||
-			deployment.State == types.DeploymentStateBaking {
+			deployment.State == types.DeploymentStateBaking ||
+			deployment.State == types.DeploymentStateValidating ||
+			deployment.State == types.DeploymentStateRollingBack ||
+			deployment.State == types.DeploymentStateReverted {
 			return true, &deployment, nil
 		}
 	}

--- a/internal/aws/deployment_test.go
+++ b/internal/aws/deployment_test.go
@@ -61,6 +61,50 @@ func TestCheckOngoingDeployment(t *testing.T) {
 			expectedErr:     false,
 		},
 		{
+			name: "has validating deployment",
+			deployments: []types.DeploymentSummary{
+				{
+					DeploymentNumber: 1,
+					State:            types.DeploymentStateValidating,
+				},
+			},
+			expectedOngoing: true,
+			expectedErr:     false,
+		},
+		{
+			name: "has rolling back deployment",
+			deployments: []types.DeploymentSummary{
+				{
+					DeploymentNumber: 1,
+					State:            types.DeploymentStateRollingBack,
+				},
+			},
+			expectedOngoing: true,
+			expectedErr:     false,
+		},
+		{
+			name: "has reverted deployment",
+			deployments: []types.DeploymentSummary{
+				{
+					DeploymentNumber: 1,
+					State:            types.DeploymentStateReverted,
+				},
+			},
+			expectedOngoing: true,
+			expectedErr:     false,
+		},
+		{
+			name: "rolled back deployment is not ongoing",
+			deployments: []types.DeploymentSummary{
+				{
+					DeploymentNumber: 1,
+					State:            types.DeploymentStateRolledBack,
+				},
+			},
+			expectedOngoing: false,
+			expectedErr:     false,
+		},
+		{
 			name: "mixed states",
 			deployments: []types.DeploymentSummary{
 				{

--- a/internal/aws/deployment_test.go
+++ b/internal/aws/deployment_test.go
@@ -83,14 +83,14 @@ func TestCheckOngoingDeployment(t *testing.T) {
 			expectedErr:     false,
 		},
 		{
-			name: "has reverted deployment",
+			name: "reverted deployment is not ongoing",
 			deployments: []types.DeploymentSummary{
 				{
 					DeploymentNumber: 1,
 					State:            types.DeploymentStateReverted,
 				},
 			},
-			expectedOngoing: true,
+			expectedOngoing: false,
 			expectedErr:     false,
 		},
 		{


### PR DESCRIPTION
## Summary

- `CheckOngoingDeployment` previously only classified `DEPLOYING` and `BAKING` as in-flight states, missing `VALIDATING` and `ROLLING_BACK`
- This caused `run`'s pre-deploy guard to be bypassable (AWS then returns a less-friendly `ConflictException`) and `rollback` to falsely report "no ongoing deployment" while one was actually `ROLLING_BACK`
- `REVERTED` (alongside `ROLLED_BACK` / `COMPLETE`) is a terminal state and is deliberately **not** treated as ongoing: these states persist in the deployment history indefinitely, so treating one as "ongoing" would permanently block run/edit and make rollback try to stop a finished deployment. Issue #101 only suggested to "consider" `REVERTED`; on review it belongs with the terminal states.

## What changed

- `internal/aws/deployment.go`: extended the in-flight state check in `CheckOngoingDeployment` to include `DeploymentStateValidating` and `DeploymentStateRollingBack`
- `internal/aws/deployment_test.go`: added four table-driven test cases — the two new in-flight states (`VALIDATING`, `ROLLING_BACK`) classified as ongoing, plus `REVERTED` and `ROLLED_BACK` (terminal) asserted to be correctly **not** classified as ongoing

## How tested

- New failing tests written first (TDD); all pass after the fix
- `go test ./internal/aws/... -run TestCheckOngoingDeployment` — green
- `mise run ci` — all packages pass, coverage at 91.4% (maintained)

Closes #101
