### PR TITLE
fix(aws): handle VALIDATING and ROLLING_BACK states in wait loops

### DIFF
--- a/internal/aws/deployment.go
+++ b/internal/aws/deployment.go
@@ -196,9 +196,18 @@ func (c *Client) waitForDeploymentWithCondition(
 		case types.DeploymentStateRolledBack:
 			return false, rolledBackError(output.EventLog)
 
-		case types.DeploymentStateDeploying:
-			// Still deploying
+		case types.DeploymentStateDeploying, types.DeploymentStateValidating:
+			// Still in progress
 			return false, nil
+
+		case types.DeploymentStateRollingBack:
+			// Auto-rollback in progress; keep polling until ROLLED_BACK
+			// so that rolledBackError can surface the reason from the event log.
+			return false, nil
+
+		case types.DeploymentStateReverted:
+			// Terminal state: deployment was explicitly reverted to a previous version.
+			return false, fmt.Errorf("deployment was reverted")
 
 		default:
 			// Unexpected state
@@ -329,6 +338,15 @@ func (c *Client) WaitForBakingComplete(
 
 		case types.DeploymentStateRolledBack:
 			return false, rolledBackError(output.EventLog)
+
+		case types.DeploymentStateRollingBack:
+			// Auto-rollback in progress; keep polling until ROLLED_BACK
+			// so that rolledBackError can surface the reason from the event log.
+			return false, nil
+
+		case types.DeploymentStateReverted:
+			// Terminal state: deployment was explicitly reverted to a previous version.
+			return false, fmt.Errorf("deployment was reverted")
 
 		default:
 			return false, fmt.Errorf("unexpected deployment state during bake wait: %s", output.State)

--- a/internal/aws/deployment_test.go
+++ b/internal/aws/deployment_test.go
@@ -919,6 +919,73 @@ func TestWaitForDeploymentPhase(t *testing.T) {
 			wantErr:       true,
 			wantErrMsg:    "deployment timed out",
 		},
+		// VALIDATING: transient state right after StartDeployment; must keep polling
+		{
+			name:          "wait for deploy: VALIDATING then DEPLOYING then BAKING succeeds",
+			deploymentNum: 10,
+			waitForBaking: false,
+			mockStates:    []types.DeploymentState{types.DeploymentStateValidating, types.DeploymentStateDeploying, types.DeploymentStateBaking},
+			timeout:       10 * time.Second,
+			wantErr:       false,
+		},
+		{
+			name:          "wait for bake: VALIDATING then DEPLOYING then BAKING then COMPLETE succeeds",
+			deploymentNum: 11,
+			waitForBaking: true,
+			mockStates:    []types.DeploymentState{types.DeploymentStateValidating, types.DeploymentStateDeploying, types.DeploymentStateBaking, types.DeploymentStateComplete},
+			timeout:       10 * time.Second,
+			wantErr:       false,
+		},
+		// ROLLING_BACK: keep polling until ROLLED_BACK so we can surface the reason
+		{
+			name:          "wait for deploy: ROLLING_BACK then ROLLED_BACK surfaces rollback reason",
+			deploymentNum: 12,
+			waitForBaking: false,
+			mockStates:    []types.DeploymentState{types.DeploymentStateDeploying, types.DeploymentStateRollingBack, types.DeploymentStateRolledBack},
+			mockEventLog: []types.DeploymentEvent{
+				{
+					EventType:   types.DeploymentEventTypeRollbackStarted,
+					Description: new("CloudWatch alarm triggered rollback"),
+				},
+			},
+			timeout:    10 * time.Second,
+			wantErr:    true,
+			wantErrMsg: "deployment was rolled back: CloudWatch alarm triggered rollback",
+		},
+		{
+			name:          "wait for bake: BAKING then ROLLING_BACK then ROLLED_BACK surfaces rollback reason",
+			deploymentNum: 13,
+			waitForBaking: true,
+			mockStates:    []types.DeploymentState{types.DeploymentStateBaking, types.DeploymentStateRollingBack, types.DeploymentStateRolledBack},
+			mockEventLog: []types.DeploymentEvent{
+				{
+					EventType:   types.DeploymentEventTypeRollbackStarted,
+					Description: new("auto-rollback due to alarm"),
+				},
+			},
+			timeout:    10 * time.Second,
+			wantErr:    true,
+			wantErrMsg: "deployment was rolled back: auto-rollback due to alarm",
+		},
+		// REVERTED: terminal state — surface as error
+		{
+			name:          "wait for deploy: REVERTED is a terminal error",
+			deploymentNum: 14,
+			waitForBaking: false,
+			mockStates:    []types.DeploymentState{types.DeploymentStateReverted},
+			timeout:       10 * time.Second,
+			wantErr:       true,
+			wantErrMsg:    "deployment was reverted",
+		},
+		{
+			name:          "wait for bake: REVERTED is a terminal error",
+			deploymentNum: 15,
+			waitForBaking: true,
+			mockStates:    []types.DeploymentState{types.DeploymentStateReverted},
+			timeout:       10 * time.Second,
+			wantErr:       true,
+			wantErrMsg:    "deployment was reverted",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1212,6 +1279,25 @@ func TestWaitForBakingComplete(t *testing.T) {
 			timeout:     2 * time.Second,
 			wantErr:     true,
 			wantErrMsg:  "unexpected deployment state during bake wait",
+		},
+		// ROLLING_BACK: auto-rollback during bake; keep polling until ROLLED_BACK
+		{
+			name:         "ROLLING_BACK then ROLLED_BACK surfaces rollback reason",
+			mockStates:   []types.DeploymentState{types.DeploymentStateBaking, types.DeploymentStateRollingBack, types.DeploymentStateRolledBack},
+			mockEventLog: []types.DeploymentEvent{{EventType: types.DeploymentEventTypeRollbackStarted, Description: new("alarm fired")}},
+			bakeMinutes:  1,
+			timeout:      2 * time.Second,
+			wantErr:      true,
+			wantErrMsg:   "deployment was rolled back: alarm fired",
+		},
+		// REVERTED: terminal state — surface as error
+		{
+			name:        "REVERTED is a terminal error",
+			mockStates:  []types.DeploymentState{types.DeploymentStateReverted},
+			bakeMinutes: 1,
+			timeout:     2 * time.Second,
+			wantErr:     true,
+			wantErrMsg:  "deployment was reverted",
 		},
 		{
 			name:        "timeout while still baking",


### PR DESCRIPTION
## Summary

- `VALIDATING` (transient state right after `StartDeployment`) was hitting the `default` branch in `waitForDeploymentWithCondition` and aborting with `"unexpected deployment state: VALIDATING"` instead of continuing to poll.
- `ROLLING_BACK` (auto-rollback in progress) was similarly aborting in both `waitForDeploymentWithCondition` and `WaitForBakingComplete` instead of polling through to `ROLLED_BACK` so the rollback reason from the event log could be surfaced.
- `REVERTED` is now an explicit terminal error (`"deployment was reverted"`) in both wait loops, replacing the generic `"unexpected deployment state: REVERTED"` message.

## What changed

**`internal/aws/deployment.go`**

`waitForDeploymentWithCondition` switch:
- Added `types.DeploymentStateValidating` to the `DEPLOYING` case (keep polling).
- Added explicit `types.DeploymentStateRollingBack` case: keep polling until `ROLLED_BACK` so `rolledBackError` can extract the reason from the event log.
- Added explicit `types.DeploymentStateReverted` case: return `"deployment was reverted"` as a terminal error.

`WaitForBakingComplete` switch:
- Added explicit `types.DeploymentStateRollingBack` case: keep polling (same rationale as above).
- Added explicit `types.DeploymentStateReverted` case: return `"deployment was reverted"`.

`CheckOngoingDeployment` was deliberately **not** modified (separate PR scope).

## REVERTED decision

`REVERTED` indicates that `StopDeployment` was called with `AllowRevert=true`, reverting the environment to a prior version. `apcdeploy rollback` never sets `AllowRevert`, so encountering `REVERTED` in a wait loop means something external acted on the deployment. Treating it as a terminal failure (rather than success) is the correct behaviour: the config the user deployed did not take effect.

## How tested

Table-driven tests added to `TestWaitForDeploymentPhase` and `TestWaitForBakingComplete` in `internal/aws/deployment_test.go`:

- `VALIDATING → DEPLOYING → BAKING` succeeds for `--wait-deploy`
- `VALIDATING → DEPLOYING → BAKING → COMPLETE` succeeds for `--wait-bake`
- `DEPLOYING → ROLLING_BACK → ROLLED_BACK` surfaces rollback reason for `--wait-deploy`
- `BAKING → ROLLING_BACK → ROLLED_BACK` surfaces rollback reason for `--wait-bake` (both via `WaitForDeploymentPhase` and `WaitForBakingComplete`)
- `REVERTED` returns `"deployment was reverted"` in both wait functions

All existing tests continue to pass. Full `mise run ci` green (coverage 91.3%).

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)