### PR TITLE
fix(cli): use display-cell width for Targets column and truncation

### DIFF
--- a/internal/cli/reporter.go
+++ b/internal/cli/reporter.go
@@ -164,13 +164,9 @@ func colorizeDiffLine(line string) string {
 	}
 }
 
-// visibleWidth returns the rune count of s, used for header underline width.
-// Lipgloss color codes never reach this helper because callers pass the raw
-// string before styling.
+// visibleWidth returns the terminal display width of s in cells.
+// Full-width characters (e.g. CJK) each count as 2 cells; ANSI escape
+// sequences count as 0. Uses lipgloss.Width which already handles both.
 func visibleWidth(s string) int {
-	n := 0
-	for range s {
-		n++
-	}
-	return n
+	return lipgloss.Width(s)
 }

--- a/internal/cli/reporter_tty_test.go
+++ b/internal/cli/reporter_tty_test.go
@@ -172,15 +172,19 @@ func TestVisibleWidth(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		name string
 		in   string
 		want int
 	}{
-		{"", 0},
-		{"abc", 3},
-		{"日本語", 3},
+		{name: "empty", in: "", want: 0},
+		{name: "ascii", in: "abc", want: 3},
+		// Full-width CJK: each rune is 2 display cells, so 3 runes → 6 cells.
+		{name: "CJK three runes", in: "日本語", want: 6},
+		// ANSI escape sequences must contribute 0 cells.
+		{name: "ANSI stripped", in: "\x1b[31mred\x1b[0m", want: 3},
 	}
 	for _, tt := range tests {
-		t.Run(tt.in, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := visibleWidth(tt.in); got != tt.want {
 				t.Errorf("visibleWidth(%q) = %d, want %d", tt.in, got, tt.want)

--- a/internal/cli/targets.go
+++ b/internal/cli/targets.go
@@ -110,27 +110,40 @@ func idColumnWidth(ids []string) int {
 	return w + targetsIDGap
 }
 
-// truncateRunes shortens s to at most limit runes, appending an ellipsis
-// (…) when truncation actually happens. Returns "" for limit <= 0 and "…"
-// for limit == 1 — at one rune of budget the ellipsis itself is the only
-// thing that fits.
+// truncateCells shortens s so that its terminal display width does not exceed
+// limit cells, appending an ellipsis (…, 1 cell wide) when truncation
+// actually happens. Returns "" for limit <= 0 and "…" for limit == 1 — at
+// one cell of budget the ellipsis itself is the only thing that fits.
 //
-// Used by the TTY Targets renderer to keep each row within terminal
-// width: row contents that wrap to a second visual line break the redraw
-// math (\033[NA assumes one terminal line per row), and either accumulate
-// stale fragments or eat earlier rows.
-func truncateRunes(s string, limit int) string {
+// Used by the TTY Targets renderer to keep each row within terminal width:
+// row contents that wrap to a second visual line break the redraw math
+// (\033[NA assumes one terminal line per row), and either accumulate stale
+// fragments or eat earlier rows. Full-width (CJK) characters each occupy 2
+// cells, so rune-counting underestimates their display cost.
+func truncateCells(s string, limit int) string {
 	if limit <= 0 {
 		return ""
 	}
-	runes := []rune(s)
-	if len(runes) <= limit {
+	if visibleWidth(s) <= limit {
 		return s
 	}
 	if limit == 1 {
 		return "…"
 	}
-	return string(runes[:limit-1]) + "…"
+	// Walk runes left-to-right, accumulating cell width until we exhaust the
+	// budget (limit-1 cells, reserving 1 for the ellipsis).
+	budget := limit - 1 // cells available for content (ellipsis takes 1)
+	used := 0
+	var b strings.Builder
+	for _, r := range s {
+		w := visibleWidth(string(r))
+		if used+w > budget {
+			break
+		}
+		b.WriteRune(r)
+		used += w
+	}
+	return b.String() + "…"
 }
 
 // padID returns id padded with spaces to width.

--- a/internal/cli/targets_test.go
+++ b/internal/cli/targets_test.go
@@ -115,12 +115,43 @@ func TestIDColumnWidth(t *testing.T) {
 		{name: "empty", ids: nil, want: 3},
 		{name: "single", ids: []string{"a"}, want: 4},
 		{name: "longest wins", ids: []string{"abc", "ab", "abcdef"}, want: 9},
+		// Full-width CJK characters each occupy 2 terminal cells.
+		// "東京" is 2 runes but 4 display cells → column width = 4+3 = 7.
+		{name: "CJK double-width", ids: []string{"東京"}, want: 7},
+		// Mix of ASCII and CJK: "ab東京" = 2 + 4 = 6 cells.
+		{name: "mixed ascii+CJK", ids: []string{"ab東京", "abcde"}, want: 9},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := idColumnWidth(tt.ids); got != tt.want {
 				t.Errorf("idColumnWidth(%v) = %d, want %d", tt.ids, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisibleWidthWideChars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		s    string
+		want int
+	}{
+		{name: "empty", s: "", want: 0},
+		{name: "ascii", s: "hello", want: 5},
+		// Full-width CJK: each rune is 2 display cells.
+		{name: "CJK two runes", s: "東京", want: 4},
+		{name: "mixed ascii+CJK", s: "ab東京", want: 6},
+		// ANSI escape sequences must count as 0 cells.
+		{name: "ANSI sequences stripped", s: "\x1b[31mred\x1b[0m", want: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := visibleWidth(tt.s); got != tt.want {
+				t.Errorf("visibleWidth(%q) = %d, want %d", tt.s, got, tt.want)
 			}
 		})
 	}
@@ -166,6 +197,10 @@ func TestPadID(t *testing.T) {
 		{"abc", 3, "abc"},
 		{"abc", 2, "abc"},
 		{"", 4, "    "},
+		// "東京" is 2 runes but 4 display cells; padding to width=7 needs 3 spaces.
+		{"東京", 7, "東京   "},
+		// "東京" display width 4, target width 4 → no padding.
+		{"東京", 4, "東京"},
 	}
 	for _, tt := range tests {
 		if got := padID(tt.id, tt.width); got != tt.want {
@@ -174,7 +209,7 @@ func TestPadID(t *testing.T) {
 	}
 }
 
-func TestTruncateRunes(t *testing.T) {
+func TestTruncateCells(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -190,14 +225,28 @@ func TestTruncateRunes(t *testing.T) {
 		{"equal to limit passes through", "abc", 3, "abc"},
 		{"limit one returns ellipsis only", "abc", 1, "…"},
 		{"truncates to limit with ellipsis", "abcdef", 4, "abc…"},
-		{"multibyte truncation is rune-aware", "あいうえお", 3, "あい…"},
 		{"long ASCII", strings.Repeat("a", 100), 5, "aaaa…"},
+		// Full-width CJK: each rune = 2 cells.
+		// limit=4 cells: fits "あ" (2) + "…" (1) = 3 cells (not 4), or "あい" = 4 cells exactly.
+		// "あいうえお" with limit=4: "あい" = 4 cells, fits exactly → no truncation needed? No —
+		// len("あいうえお") = 5 runes = 10 cells > 4, so truncate: budget=4, "あ"=2 cells fits,
+		// remaining 2 cells: can we fit "い" (2 cells)? that would be 4 total but leaves 0 for "…".
+		// We need limit-1=3 cells for content: "あ"=2 fits, "い" doesn't (2 > 1). So result = "あ…".
+		{"CJK truncates at cell boundary", "あいうえお", 4, "あ…"},
+		// limit=5 cells: content budget=4 cells. "あ"=2, "い"=2 → 4 cells. Result: "あい…".
+		{"CJK limit 5", "あいうえお", 5, "あい…"},
+		// "東京" = 4 cells, limit=4 → fits exactly, no truncation.
+		{"CJK fits exactly", "東京", 4, "東京"},
+		// Mixed: "ab東" = 4 cells, limit=4 → fits.
+		{"mixed fits exactly", "ab東", 4, "ab東"},
+		// Mixed: "ab東京" = 6 cells, limit=5 → content budget=4: "ab"=2, "東"=2 → 4 cells → "ab東…".
+		{"mixed truncates", "ab東京", 5, "ab東…"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := truncateRunes(tt.in, tt.limit); got != tt.want {
-				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.in, tt.limit, got, tt.want)
+			if got := truncateCells(tt.in, tt.limit); got != tt.want {
+				t.Errorf("truncateCells(%q, %d) = %q, want %q", tt.in, tt.limit, got, tt.want)
 			}
 		})
 	}

--- a/internal/cli/targets_tty.go
+++ b/internal/cli/targets_tty.go
@@ -111,10 +111,10 @@ func (t *ttyTargets) formatLine(row *targetsRow, frame string) string {
 		// case). Floor at 10 so very narrow terminals still get
 		// something visible rather than a string of just ellipses.
 		budget := max(t.cols-t.idWidth-12, 10)
-		r.errMsg = truncateRunes(r.errMsg, budget)
-		r.summary = truncateRunes(r.summary, budget)
-		r.detail = truncateRunes(r.detail, budget)
-		r.reason = truncateRunes(r.reason, budget)
+		r.errMsg = truncateCells(r.errMsg, budget)
+		r.summary = truncateCells(r.summary, budget)
+		r.detail = truncateCells(r.detail, budget)
+		r.reason = truncateCells(r.reason, budget)
 	}
 	return padID(r.id, t.idWidth) + renderRow(&r, frame)
 }

--- a/internal/cli/targets_tty_test.go
+++ b/internal/cli/targets_tty_test.go
@@ -134,13 +134,12 @@ func TestTTYTargets_TruncatesLongFields(t *testing.T) {
 	tt.Close()
 
 	out := stripANSI(buf.String())
-	// Each line printed by ttyTargets must be ≤ cols runes (the
-	// trailing "\n" is not counted). The output may contain ANSI
-	// movement sequences but stripANSI removes them, leaving only
-	// the payload lines.
+	// Each line printed by ttyTargets must be ≤ cols display cells (the
+	// trailing "\n" is not counted). visibleWidth measures terminal cells
+	// so full-width CJK characters are counted as 2, ANSI as 0.
 	for line := range strings.SplitSeq(out, "\n") {
-		if n := len([]rune(line)); n > tt.cols {
-			t.Errorf("line of %d runes exceeds cols=%d:\n%q", n, tt.cols, line)
+		if n := visibleWidth(line); n > tt.cols {
+			t.Errorf("line of %d cells exceeds cols=%d:\n%q", n, tt.cols, line)
 		}
 	}
 	if !strings.Contains(out, "…") {


### PR DESCRIPTION
## Summary

- Replace rune-count `visibleWidth` with `lipgloss.Width` so CJK (full-width) characters count as 2 terminal cells instead of 1
- Rename `truncateRunes` → `truncateCells` with display-cell-aware truncation logic so the row-budget in `ttyTargets.formatLine` is correctly enforced for wide-char payloads
- Update all callers (`padID`, `idColumnWidth`, `formatLine`) and their tests; update the existing `TestVisibleWidth` to assert correct cell widths

## What changed

- `internal/cli/reporter.go`: `visibleWidth` delegates to `lipgloss.Width` (strips ANSI, counts wide runes as 2 cells)
- `internal/cli/targets.go`: `truncateRunes` → `truncateCells`; walks runes accumulating cell width, stops when budget exhausted
- `internal/cli/targets_tty.go`: call sites updated to `truncateCells`
- Tests (`reporter_tty_test.go`, `targets_test.go`, `targets_tty_test.go`): CJK cases added to `TestVisibleWidth`, `TestIDColumnWidth`, `TestPadID`; `TestTruncateRunes` → `TestTruncateCells` with CJK/mixed cell-boundary cases; `TestTTYTargets_TruncatesLongFields` now asserts `visibleWidth` ≤ cols rather than rune count

## How tested

- All new test cases were written before the fix (TDD) and confirmed failing, then passing after
- `mise run ci` passes with `internal/cli` coverage at 93.9%

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)