### PR TITLE
fix(aws): surface error when newest deployment's GetDeployment fails

### DIFF
--- a/internal/aws/deployment.go
+++ b/internal/aws/deployment.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -372,24 +373,29 @@ func GetLatestDeploymentIncludingRollback(ctx context.Context, client *Client, a
 	return getLatestDeploymentInternal(ctx, client, applicationID, environmentID, profileID, false)
 }
 
-// getLatestDeploymentInternal is the internal implementation for retrieving the latest deployment
+// getLatestDeploymentInternal is the internal implementation for retrieving the latest deployment.
+//
+// Deployments are sorted descending by DeploymentNumber before scanning so that the
+// newest deployment is examined first. Any GetDeployment error causes an immediate
+// return — if we cannot fetch details for a deployment we have no way to determine
+// whether it is the true latest for the requested profile, so silently skipping it
+// could cause callers (run / diff / pull) to compare against an older version.
 func getLatestDeploymentInternal(ctx context.Context, client *Client, applicationID, environmentID, profileID string, skipRolledBack bool) (*DeploymentInfo, error) {
 	deployments, err := client.ListAllDeployments(ctx, applicationID, environmentID)
 	if err != nil {
 		return nil, wrapAWSError(err, "failed to list deployments")
 	}
 
-	// Find the latest deployment for this configuration profile
-	// We need to get full deployment details to access ConfigurationProfileId
-	var (
-		latestDeployment *DeploymentInfo
-		lastErr          error
-		fetchedCount     int
-	)
+	// Sort newest-first so we examine the highest deployment number first.
+	sort.Slice(deployments, func(i, j int) bool {
+		return deployments[i].DeploymentNumber > deployments[j].DeploymentNumber
+	})
+
+	// Find the latest deployment for this configuration profile.
+	// We need to get full deployment details to access ConfigurationProfileId.
 	for i := range deployments {
 		summary := &deployments[i]
 
-		// Get full deployment details
 		getInput := &appconfig.GetDeploymentInput{
 			ApplicationId:    aws.String(applicationID),
 			EnvironmentId:    aws.String(environmentID),
@@ -398,41 +404,32 @@ func getLatestDeploymentInternal(ctx context.Context, client *Client, applicatio
 
 		deployment, err := client.appConfig.GetDeployment(ctx, getInput)
 		if err != nil {
-			// Track the failure but keep going — a single transient error
-			// shouldn't hide an otherwise-discoverable deployment.
-			lastErr = err
+			// Fail fast: if any GetDeployment call errors we cannot be certain
+			// which deployment is truly the latest for this profile, so surfacing
+			// the error is safer than silently returning an older deployment.
+			return nil, wrapAWSError(err, "failed to fetch deployment details")
+		}
+
+		// Skip deployments that belong to a different configuration profile.
+		if aws.ToString(deployment.ConfigurationProfileId) != profileID {
 			continue
 		}
-		fetchedCount++
 
-		// Check if this is for the target configuration profile
-		if aws.ToString(deployment.ConfigurationProfileId) == profileID {
-			// Skip ROLLED_BACK deployments if requested
-			if skipRolledBack && deployment.State == types.DeploymentStateRolledBack {
-				continue
-			}
-
-			if latestDeployment == nil || summary.DeploymentNumber > latestDeployment.DeploymentNumber {
-				latestDeployment = &DeploymentInfo{
-					DeploymentNumber:     summary.DeploymentNumber,
-					ConfigurationVersion: aws.ToString(deployment.ConfigurationVersion),
-					DeploymentStrategyID: aws.ToString(deployment.DeploymentStrategyId),
-					State:                deployment.State,
-					Description:          aws.ToString(deployment.Description),
-				}
-			}
+		// Skip ROLLED_BACK deployments if requested.
+		if skipRolledBack && deployment.State == types.DeploymentStateRolledBack {
+			continue
 		}
+
+		return &DeploymentInfo{
+			DeploymentNumber:     summary.DeploymentNumber,
+			ConfigurationVersion: aws.ToString(deployment.ConfigurationVersion),
+			DeploymentStrategyID: aws.ToString(deployment.DeploymentStrategyId),
+			State:                deployment.State,
+			Description:          aws.ToString(deployment.Description),
+		}, nil
 	}
 
-	// If every GetDeployment failed (e.g. throttling, IAM regression),
-	// surface the underlying error rather than returning nil — a nil
-	// result is the "no deployment" signal and would be misinterpreted
-	// as "first-time setup" by callers (pull / edit / run skip-unchanged).
-	if latestDeployment == nil && fetchedCount == 0 && lastErr != nil {
-		return nil, wrapAWSError(lastErr, "failed to fetch any deployment details")
-	}
-
-	return latestDeployment, nil
+	return nil, nil
 }
 
 // GetHostedConfigurationVersion retrieves the content of a specific hosted configuration version

--- a/internal/aws/deployment_test.go
+++ b/internal/aws/deployment_test.go
@@ -607,43 +607,100 @@ func TestGetLatestDeployment_AllGetDeploymentFail(t *testing.T) {
 	}
 }
 
-// TestGetLatestDeployment_PartialGetDeploymentFail covers the case where some
-// GetDeployment calls fail but others succeed: the function should still find
-// and return the latest deployment from the successful subset, not error out.
-func TestGetLatestDeployment_PartialGetDeploymentFail(t *testing.T) {
+// TestGetLatestDeployment_NewestGetDeploymentFails verifies that when the newest
+// deployment's GetDeployment call fails, the function surfaces that error rather
+// than silently returning an older deployment as "latest".
+//
+// Before the fix, if deployments [1, 2, 3] existed and GetDeployment(3) failed
+// transiently (e.g. throttling) while GetDeployment(2) and GetDeployment(1)
+// succeeded, the loop would accept deployment 2 as "latest" with no error.
+// Downstream run / diff / pull would then compare against the wrong (older)
+// version, producing wrong diffs or incorrect no-op decisions.
+//
+// The fix sorts deployments newest-first and fails fast on any GetDeployment
+// error, so a transient failure on the newest deployment propagates as an error
+// instead of being silently swallowed.
+func TestGetLatestDeployment_NewestGetDeploymentFails(t *testing.T) {
 	t.Parallel()
-	mockClient := &mock.MockAppConfigClient{
-		ListDeploymentsFunc: func(ctx context.Context, params *appconfig.ListDeploymentsInput, optFns ...func(*appconfig.Options)) (*appconfig.ListDeploymentsOutput, error) {
-			return &appconfig.ListDeploymentsOutput{
-				Items: []types.DeploymentSummary{
-					{DeploymentNumber: 1},
-					{DeploymentNumber: 2},
-				},
-			}, nil
+	tests := []struct {
+		name              string
+		deployments       []types.DeploymentSummary
+		getDeploymentFunc func(ctx context.Context, params *appconfig.GetDeploymentInput, optFns ...func(*appconfig.Options)) (*appconfig.GetDeploymentOutput, error)
+		profileID         string
+		wantErr           bool
+		wantDeployNum     int32
+	}{
+		{
+			name: "newest deployment fetch fails, older succeeds — must error",
+			deployments: []types.DeploymentSummary{
+				{DeploymentNumber: 1},
+				{DeploymentNumber: 3},
+				{DeploymentNumber: 2},
+			},
+			getDeploymentFunc: func(ctx context.Context, params *appconfig.GetDeploymentInput, optFns ...func(*appconfig.Options)) (*appconfig.GetDeploymentOutput, error) {
+				if *params.DeploymentNumber == 3 {
+					return nil, errors.New("ThrottlingException: rate exceeded for deployment 3")
+				}
+				return &appconfig.GetDeploymentOutput{
+					DeploymentNumber:       *params.DeploymentNumber,
+					ConfigurationProfileId: new("profile-123"),
+					ConfigurationVersion:   new("5"),
+					State:                  types.DeploymentStateComplete,
+				}, nil
+			},
+			profileID: "profile-123",
+			wantErr:   true,
 		},
-		GetDeploymentFunc: func(ctx context.Context, params *appconfig.GetDeploymentInput, optFns ...func(*appconfig.Options)) (*appconfig.GetDeploymentOutput, error) {
-			if *params.DeploymentNumber == 1 {
-				return nil, errors.New("transient throttle on deployment 1")
-			}
-			return &appconfig.GetDeploymentOutput{
-				DeploymentNumber:       *params.DeploymentNumber,
-				ConfigurationProfileId: new("profile-123"),
-				ConfigurationVersion:   new("9"),
-				State:                  types.DeploymentStateComplete,
-			}, nil
+		{
+			name: "oldest deployment fetch fails, newest succeeds — must succeed",
+			deployments: []types.DeploymentSummary{
+				{DeploymentNumber: 1},
+				{DeploymentNumber: 2},
+			},
+			getDeploymentFunc: func(ctx context.Context, params *appconfig.GetDeploymentInput, optFns ...func(*appconfig.Options)) (*appconfig.GetDeploymentOutput, error) {
+				if *params.DeploymentNumber == 1 {
+					return nil, errors.New("ThrottlingException: rate exceeded for deployment 1")
+				}
+				return &appconfig.GetDeploymentOutput{
+					DeploymentNumber:       *params.DeploymentNumber,
+					ConfigurationProfileId: new("profile-123"),
+					ConfigurationVersion:   new("9"),
+					State:                  types.DeploymentStateComplete,
+				}, nil
+			},
+			profileID:     "profile-123",
+			wantErr:       false,
+			wantDeployNum: 2,
 		},
 	}
 
-	client := &Client{appConfig: mockClient}
-	deployment, err := GetLatestDeployment(context.Background(), client, "app-123", "env-123", "profile-123")
-	if err != nil {
-		t.Fatalf("expected partial failure to be tolerated, got %v", err)
-	}
-	if deployment == nil {
-		t.Fatal("expected deployment from successful subset, got nil")
-	}
-	if deployment.DeploymentNumber != 2 {
-		t.Errorf("DeploymentNumber = %d, want 2", deployment.DeploymentNumber)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mockClient := &mock.MockAppConfigClient{
+				ListDeploymentsFunc: func(ctx context.Context, params *appconfig.ListDeploymentsInput, optFns ...func(*appconfig.Options)) (*appconfig.ListDeploymentsOutput, error) {
+					return &appconfig.ListDeploymentsOutput{
+						Items: tt.deployments,
+					}, nil
+				},
+				GetDeploymentFunc: tt.getDeploymentFunc,
+			}
+
+			client := &Client{appConfig: mockClient}
+			deployment, err := GetLatestDeployment(context.Background(), client, "app-123", "env-123", tt.profileID)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("GetLatestDeployment() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if deployment == nil {
+					t.Fatal("expected a deployment, got nil")
+				}
+				if deployment.DeploymentNumber != tt.wantDeployNum {
+					t.Errorf("DeploymentNumber = %d, want %d", deployment.DeploymentNumber, tt.wantDeployNum)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- `getLatestDeploymentInternal` iterated all deployments and skipped any where `GetDeployment` errored, tracking only the last error. The error gate at the end only fired when **every** call failed, so a transient failure on the newest deployment was silently absorbed and an older deployment was returned as "latest".
- This could cause `run` / `diff` / `pull` to compare local content against the wrong (older) deployed version, producing incorrect diffs or false no-op decisions.

## What changed

**`internal/aws/deployment.go`**

1. Sort the deployments slice **descending by `DeploymentNumber`** before scanning, so the newest deployment is examined first.
2. **Fail fast on any `GetDeployment` error**: if a fetch fails we have no way to know whether that deployment belongs to the target profile or is actually the true latest, so the error is surfaced immediately instead of being swallowed.
3. Since the list is now newest-first, the loop returns on the **first** deployment that matches the target profile and passes the state filter — eliminating the previous O(n) scan + max-tracking in favour of a simple early-return.

**Design choice — fail fast vs. skip-and-continue**

The issue suggests two options. "Fetch newest-first, fail fast" was chosen because:
- It matches the semantics callers expect: "give me the latest, or tell me you can't".
- A transient throttle on any deployment is a signal that the AWS endpoint is under pressure; retrying from the caller is safer than guessing from stale data.
- The resulting code is simpler (no `latestDeployment` accumulator or `fetchedCount` book-keeping).

**`internal/aws/deployment_test.go`**

- Replaced `TestGetLatestDeployment_PartialGetDeploymentFail` (which tested the old tolerant-but-incorrect behaviour) with `TestGetLatestDeployment_NewestGetDeploymentFails`, a table-driven test covering:
  - Newest deployment fetch fails, older succeeds → **must return error** (the bug case).
  - Oldest deployment fetch fails, newest succeeds → **must succeed** (no regression).

## How tested

- New test `TestGetLatestDeployment_NewestGetDeploymentFails` was written first (TDD red), then the fix was applied (green).
- All existing `TestGetLatestDeployment*` and `TestGetLatestDeploymentIncludingRollback*` tests still pass.
- `mise run ci` passes; overall coverage 91.2% (no regression).

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)