### PR TITLE
fix(rollback): use consistent (y/N) prompt label for confirmation

### DIFF
--- a/internal/rollback/executor.go
+++ b/internal/rollback/executor.go
@@ -101,7 +101,7 @@ func (e *Executor) Execute(ctx context.Context, opts *Options) error {
 		// Targets avoids the in-place renderer fighting with the prompt.
 		display.DeploymentStatus(e.reporter, details, cfg, resources)
 
-		message := fmt.Sprintf("Stop deployment #%d? This will rollback the deployment. (Y/Yes)", deploymentNumber)
+		message := fmt.Sprintf("Stop deployment #%d? This will rollback the deployment. (y/N)", deploymentNumber)
 		response, err := e.prompter.Input(message, "")
 		if err != nil {
 			return fmt.Errorf("failed to get user confirmation: %w", err)

--- a/internal/rollback/executor_test.go
+++ b/internal/rollback/executor_test.go
@@ -662,6 +662,62 @@ func TestExecutorTargetsDoneOnSuccess(t *testing.T) {
 	}
 }
 
+func TestExecutorConfirmationPromptLabel(t *testing.T) {
+	t.Parallel()
+
+	configPath := createTestConfig(t)
+
+	mockClient := createStandardMockClient(
+		func(ctx context.Context, params *appconfig.ListDeploymentsInput, optFns ...func(*appconfig.Options)) (*appconfig.ListDeploymentsOutput, error) {
+			return &appconfig.ListDeploymentsOutput{
+				Items: []types.DeploymentSummary{
+					{DeploymentNumber: 3, State: types.DeploymentStateDeploying},
+				},
+			}, nil
+		},
+		func(ctx context.Context, params *appconfig.GetDeploymentInput, optFns ...func(*appconfig.Options)) (*appconfig.GetDeploymentOutput, error) {
+			n := int32(3)
+			return &appconfig.GetDeploymentOutput{
+				DeploymentNumber:       n,
+				ConfigurationProfileId: aws.String("profile-123"),
+				ConfigurationVersion:   aws.String("1"),
+				DeploymentStrategyId:   aws.String("strategy-123"),
+				State:                  types.DeploymentStateDeploying,
+				StartedAt:              aws.Time(time.Now()),
+			}, nil
+		},
+		func(ctx context.Context, params *appconfig.StopDeploymentInput, optFns ...func(*appconfig.Options)) (*appconfig.StopDeploymentOutput, error) {
+			return &appconfig.StopDeploymentOutput{}, nil
+		},
+	)
+
+	var capturedMessage string
+	rep := &reportertest.MockReporter{}
+	prompter := &prompttest.MockPrompter{
+		InputFunc: func(message string, placeholder string) (string, error) {
+			capturedMessage = message
+			return "y", nil
+		},
+	}
+	executor := NewExecutorWithFactory(rep, prompter, func(ctx context.Context, region string) (*awsInternal.Client, error) {
+		return awsInternal.NewTestClient(mockClient), nil
+	})
+
+	err := executor.Execute(context.Background(), &Options{ConfigFile: configPath})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// The prompt label must use (y/N) style, consistent with get's confirmation prompt.
+	// (Y/Yes) was misleading because empty input defaults to No.
+	if !strings.Contains(capturedMessage, "(y/N)") {
+		t.Errorf("expected confirmation prompt to contain '(y/N)', got %q", capturedMessage)
+	}
+	if strings.Contains(capturedMessage, "(Y/Yes)") {
+		t.Errorf("confirmation prompt must not use '(Y/Yes)' style, got %q", capturedMessage)
+	}
+}
+
 func TestExecutorTargetsFailOnStopError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- The `rollback` confirmation prompt displayed `(Y/Yes)` which was misleading: it implied uppercase Y was required, but empty input actually defaults to No (the prompt only accepts `y`/`yes`).
- Changed the label to `(y/N)` to match `get`'s existing convention, where lowercase `y` and uppercase `N` correctly signal which is the affirmative response and which is the default.

## What changed

- `internal/rollback/executor.go` line 104: `(Y/Yes)` → `(y/N)` in the `Sprintf` format string.

## How tested

- Added `TestExecutorConfirmationPromptLabel` in `internal/rollback/executor_test.go` — captures the message passed to `prompter.Input` and asserts it contains `(y/N)` and does not contain `(Y/Yes)`.
- All existing rollback tests continue to pass.
- `mise run ci` passes with 91.3% overall coverage (no decrease).

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)