### PR TITLE
fix(pull): count no-change case as no-op via Skip instead of Done

### DIFF
--- a/internal/pull/executor.go
+++ b/internal/pull/executor.go
@@ -42,7 +42,7 @@ func NewExecutorWithFactory(rep reporter.Reporter, factory func(context.Context,
 //
 // Output shape:
 //   - updated:        ✓ updated <data-file-path>
-//   - no changes:     ✓ no changes
+//   - no changes:     ⊘ no changes  (Skip — counted as no-op by the orchestrator)
 //   - no deployment:  ✗ failed: no deployment found  (returns aws.ErrNoDeployment)
 //   - resolve/fetch/write errors: ✗ failed: <message> (returns wrapped error)
 //
@@ -90,7 +90,7 @@ func (e *Executor) RunOnTarget(ctx context.Context, t *batch.Target, tr reporter
 			return fmt.Errorf("failed to check for changes: %w", err)
 		}
 		if !hasChanges {
-			tr.Done("no changes")
+			tr.Skip("no changes")
 			return nil
 		}
 	}

--- a/internal/pull/executor_test.go
+++ b/internal/pull/executor_test.go
@@ -616,18 +616,18 @@ region: us-east-1
 		t.Error("expected data file to NOT be modified when no changes exist")
 	}
 
-	// The no-change branch finalises the Targets row with Done("no changes")
-	// — pull is idempotent so a no-op is a successful outcome.
-	foundDone := false
+	// The no-change branch finalises the Targets row with Skip("no changes")
+	// so the orchestrator counts it as no-op, consistent with run/diff.
+	foundSkip := false
 	for _, call := range reporter.TargetsCalls {
 		for _, tr := range call.Transitions {
-			if tr.Kind == "done" && strings.Contains(tr.Summary, "no changes") {
-				foundDone = true
+			if tr.Kind == "skip" && strings.Contains(tr.Reason, "no changes") {
+				foundSkip = true
 			}
 		}
 	}
-	if !foundDone {
-		t.Errorf("expected Targets.Done('no changes'); got: %+v", reporter.TargetsCalls)
+	if !foundSkip {
+		t.Errorf("expected Targets.Skip('no changes'); got: %+v", reporter.TargetsCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `pull`'s "no changes" path called `tr.Done`, which the batch orchestrator counts as `stateOK`
- The aggregate summary line (`N ok, N no-op, N failed`) always showed `0 no-op` for `pull`, even when every target was already in sync
- `run` and `diff` already use `tr.Skip` for the analogous case, counting it as `stateNoOp`

## What changed

- `internal/pull/executor.go`: changed `tr.Done("no changes")` → `tr.Skip("no changes")` at the no-op branch
- Updated the doc-comment output shape to reflect the skip icon (`⊘`) and note that the orchestrator counts it as no-op
- `internal/pull/executor_test.go`: updated `TestExecutorNoChanges` to assert `Targets.Skip("no changes")` instead of `Targets.Done("no changes")`

## How tested

- Targeted: `go test ./internal/pull/... ./internal/batch/... -count=1` — all pass
- Full CI: `mise run ci` — all tests pass, coverage 91.3% (unchanged)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)