### PR TITLE
fix(diff): render blank-line additions/removals in unified diff body

### DIFF
--- a/internal/diff/calculator.go
+++ b/internal/diff/calculator.go
@@ -99,7 +99,10 @@ func calculate(remoteContent, localContent, fileName, profileType string) (*Resu
 //   - "-" for deleted lines
 //   - " " for context lines (unchanged)
 //
-// Empty lines are skipped to produce a cleaner output.
+// go-diff splits text on "\n", which produces a trailing empty token after
+// every newline-terminated line. That sentinel is skipped; all other lines
+// (including intentionally blank ones) are emitted so the rendered body
+// agrees with HasChanges and the "N lines changed" count.
 //
 // Parameters:
 //   - diffs: Slice of diff chunks from go-diff library
@@ -110,10 +113,13 @@ func formatDiffs(diffs []diffmatchpatch.Diff) string {
 	var result strings.Builder
 
 	for _, diff := range diffs {
-		lines := strings.SplitSeq(diff.Text, "\n")
-		for line := range lines {
-			// Skip empty lines
-			if line == "" {
+		lines := strings.Split(diff.Text, "\n")
+		for i, line := range lines {
+			// Skip the trailing empty token produced by a newline-terminated
+			// chunk (the last element after splitting "a\nb\n" is "").
+			// Genuine blank lines in the middle of the text have a non-last
+			// index, so they are still rendered.
+			if line == "" && i == len(lines)-1 {
 				continue
 			}
 

--- a/internal/diff/calculator_test.go
+++ b/internal/diff/calculator_test.go
@@ -418,6 +418,77 @@ func TestCalculateResult(t *testing.T) {
 	}
 }
 
+// TestFormatDiffs_BlankLines verifies that blank-line additions and removals are
+// rendered in the diff body (prefixed with '+'/'-') so the visible output agrees
+// with HasChanges and the "N lines changed" summary.
+// Regression test for issue #108.
+func TestFormatDiffs_BlankLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		remoteContent  string
+		localContent   string
+		fileName       string
+		wantHasChanges bool
+		// wantDiffContains is the prefix character ('+' or '-') that must
+		// appear on at least one line of the rendered diff.
+		wantDiffContains string
+	}{
+		{
+			name:             "blank line added",
+			remoteContent:    "line1\nline2\n",
+			localContent:     "line1\n\nline2\n",
+			fileName:         "config.txt",
+			wantHasChanges:   true,
+			wantDiffContains: "+",
+		},
+		{
+			name:             "blank line removed",
+			remoteContent:    "line1\n\nline2\n",
+			localContent:     "line1\nline2\n",
+			fileName:         "config.txt",
+			wantHasChanges:   true,
+			wantDiffContains: "-",
+		},
+		{
+			name:             "blank line added in text file (multiple lines)",
+			remoteContent:    "line1\nline2\nline3\n",
+			localContent:     "line1\n\nline2\nline3\n",
+			fileName:         "config.txt",
+			wantHasChanges:   true,
+			wantDiffContains: "+",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := calculate(tt.remoteContent, tt.localContent, tt.fileName, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.HasChanges != tt.wantHasChanges {
+				t.Errorf("HasChanges = %v, want %v", result.HasChanges, tt.wantHasChanges)
+			}
+			if result.UnifiedDiff == "" {
+				t.Error("UnifiedDiff is empty but HasChanges is true: body must reflect the change")
+			}
+			found := false
+			for line := range strings.SplitSeq(result.UnifiedDiff, "\n") {
+				if strings.HasPrefix(line, tt.wantDiffContains) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected at least one line prefixed with %q in UnifiedDiff, got:\n%s",
+					tt.wantDiffContains, result.UnifiedDiff)
+			}
+		})
+	}
+}
+
 func TestCalculateFeatureFlags(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

- `formatDiffs` in `internal/diff/calculator.go` skipped all empty lines, causing a mismatch: a change consisting only of added/removed blank lines set `HasChanges=true` and reported "N lines changed" while emitting an empty diff body.
- The fix targets only the trailing empty token produced when splitting a newline-terminated chunk (the last element after `strings.Split(s, "\n")`). Genuine blank lines at any other position are now emitted with the correct `+`/`-` prefix, so the visible diff body agrees with `HasChanges` and the change-count summary.

## What changed

- `internal/diff/calculator.go`: replaced the blanket `if line == "" { continue }` guard in `formatDiffs` with a targeted `if line == "" && i == len(lines)-1 { continue }` check. Switched from `strings.SplitSeq` to `strings.Split` to access the index.
- `internal/diff/calculator_test.go`: added `TestFormatDiffs_BlankLines` (table-driven, parallel) with three cases — blank line added, blank line removed, and blank line added in a multi-line file — that were **failing** before the fix.

## How tested

- New `TestFormatDiffs_BlankLines` tests confirmed failure before the fix and pass after.
- Full `internal/diff` package test suite passes with no regressions.
- `mise run ci` passes at 91.3% coverage.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)