### PR TITLE
fix(cli): suppress duplicate aggregate error line on single-target failure

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/koh-sh/apcdeploy/internal/apcerrors"
 	awsInternal "github.com/koh-sh/apcdeploy/internal/aws"
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	"github.com/koh-sh/apcdeploy/internal/cli"
 	"github.com/koh-sh/apcdeploy/internal/reporter"
 	"github.com/koh-sh/apcdeploy/internal/rollback"
@@ -183,7 +184,18 @@ func classifyAndReport(err error, rep reporter.Reporter) int {
 	// Funnel the top-level error through the Reporter so the styled "✗"
 	// prefix is consistent with the rest of stderr output. Both real and
 	// silent reporters always emit Error.
-	rep.Error(err.Error())
+	//
+	// Exception: a single-target batch failure is already surfaced in full
+	// by the per-target Targets.Fail (which forwards the detailed error
+	// through Error even under --silent). Emitting the aggregate
+	// "1 of 1 targets failed" summary on top would just duplicate that line,
+	// so suppress the top-level Error for that case. The multi-target
+	// "N of M" count is informative, so it is still emitted. See issue #109.
+	var aggErr *batch.AggregateError
+	singleTargetBatch := errors.As(err, &aggErr) && aggErr.Total == 1
+	if !singleTargetBatch {
+		rep.Error(err.Error())
+	}
 	// Append a Resolution: <hint> line when the underlying AWS error code
 	// has a documented remediation.
 	// Emitted via Warn (⚠) instead of Error (✗) so the visual hierarchy is

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -10,6 +10,7 @@ import (
 
 	smithy "github.com/aws/smithy-go"
 	awsInternal "github.com/koh-sh/apcdeploy/internal/aws"
+	"github.com/koh-sh/apcdeploy/internal/batch"
 	reportertest "github.com/koh-sh/apcdeploy/internal/reporter/testing"
 	"github.com/koh-sh/apcdeploy/internal/rollback"
 )
@@ -178,6 +179,34 @@ func TestClassifyAndReport(t *testing.T) {
 				"error: ",
 				"warn: Resolution: wait for the current deployment to complete or run 'apcdeploy rollback'",
 			},
+		},
+		{
+			// Single-target batch failure: the per-target Targets.Fail
+			// already surfaced the detailed error, so the aggregate
+			// "1 of 1 targets failed" summary would just duplicate it.
+			// classifyAndReport must NOT emit the top-level Error line.
+			name: "single-target AggregateError suppresses redundant aggregate line",
+			err: &batch.AggregateError{
+				Total: 1,
+				Errs:  []batch.TargetError{{Identifier: "app/prof/env", Err: errors.New("boom")}},
+			},
+			wantCode:    1,
+			wantNoError: true,
+		},
+		{
+			// Multi-target batch failure: the "N of M" count is
+			// informative (it tells the user how many of several targets
+			// failed), so the aggregate line is still emitted.
+			name: "multi-target AggregateError emits aggregate line",
+			err: &batch.AggregateError{
+				Total: 3,
+				Errs: []batch.TargetError{
+					{Identifier: "a", Err: errors.New("boom1")},
+					{Identifier: "b", Err: errors.New("boom2")},
+				},
+			},
+			wantCode:     1,
+			wantMessages: []string{"error: 2 of 3 targets failed"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Under `--silent`, a single-target `run` / `diff` / `pull` failure emitted **two** error lines on stderr:

```
✗ <detailed per-target error>     # from silentTargets.Fail → Error
✗ 1 of 1 targets failed           # from classifyAndReport (AggregateError.Error())
```

The aggregate `"1 of 1 targets failed"` summary is redundant when there is exactly one target — the per-target `Targets.Fail` (which forwards the detailed error through `Error`, even under `--silent`) already surfaced the failure.

## What changed

- `cmd/root.go`: `classifyAndReport` now skips the top-level `rep.Error(err.Error())` line when the error is a `*batch.AggregateError` with `Total == 1`. The multi-target `"N of M targets failed"` count stays informative and is still emitted. Exit-code classification (`errors.Is` over the unwrapped per-target errors) and the `Resolution:` hint are unchanged.
- This is mode-agnostic (no branching on `--silent`), so the redundant line is also dropped in non-TTY/non-silent single-target runs, where the failure is still shown via the `Targets` row and the `Errors:` section.

## How tested

- TDD: added a failing case first, then implemented the fix.
- `cmd/root_test.go::TestClassifyAndReport`: new cases — single-target `AggregateError` (`Total==1`) emits **no** top-level error line (`wantNoError`), and multi-target `AggregateError` (`Total==3`) still emits `error: 2 of 3 targets failed`.
- `mise run ci` passes (coverage 91.3%).

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)