### PR TITLE
fix(config): preserve large integer precision in NormalizeJSON

### DIFF
--- a/internal/config/normalize.go
+++ b/internal/config/normalize.go
@@ -12,6 +12,10 @@ import (
 // NormalizeJSON normalizes JSON content by parsing and re-formatting with sorted keys.
 // For FeatureFlags profile type, it removes _updatedAt and _createdAt fields recursively.
 //
+// UseNumber is used during decoding so that large integers (> 2^53) are preserved
+// exactly instead of being converted to float64, which would cause precision loss.
+// This keeps the comparison/diff path consistent with formatJSON's written output.
+//
 // Parameters:
 //   - content: JSON string to normalize
 //   - profileType: AWS AppConfig profile type (e.g., "AWS.AppConfig.FeatureFlags")
@@ -21,7 +25,9 @@ import (
 //   - error: Any error during parsing or formatting
 func NormalizeJSON(content string, profileType string) (string, error) {
 	var data any
-	if err := json.Unmarshal([]byte(content), &data); err != nil {
+	dec := json.NewDecoder(strings.NewReader(content))
+	dec.UseNumber()
+	if err := dec.Decode(&data); err != nil {
 		return "", fmt.Errorf("invalid JSON: %w", err)
 	}
 

--- a/internal/config/normalize_test.go
+++ b/internal/config/normalize_test.go
@@ -35,6 +35,23 @@ func TestNormalizeJSON(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			// Integers > 2^53 cannot be represented exactly as float64.
+			// NormalizeJSON must preserve them without precision loss so that
+			// comparison/diff paths agree with formatJSON's written output.
+			name:        "large integer preserves precision",
+			content:     `{"id":9007199254740993}`,
+			profileType: ProfileTypeFreeform,
+			want:        "{\n  \"id\": 9007199254740993\n}",
+			wantErr:     false,
+		},
+		{
+			name:        "multiple large integers preserve precision",
+			content:     `{"a":9007199254740993,"b":9007199254740994}`,
+			profileType: ProfileTypeFreeform,
+			want:        "{\n  \"a\": 9007199254740993,\n  \"b\": 9007199254740994\n}",
+			wantErr:     false,
+		},
+		{
 			name:        "invalid JSON",
 			content:     `{invalid}`,
 			profileType: ProfileTypeFreeform,
@@ -220,6 +237,24 @@ func TestHasContentChanged(t *testing.T) {
 			after:       []byte(`{"flags":{"f":{"name":"f"}}}`),
 			ext:         ".json",
 			profileType: ProfileTypeFeatureFlags,
+		},
+		{
+			// 9007199254740993 rounds to 9007199254740992 as float64, so a
+			// float64-based normalizer would treat this genuine change as a
+			// no-op. UseNumber must keep the two integers distinct.
+			name:        "large integer change is detected",
+			before:      []byte(`{"id":9007199254740992}`),
+			after:       []byte(`{"id":9007199254740993}`),
+			ext:         ".json",
+			profileType: ProfileTypeFreeform,
+			wantChanged: true,
+		},
+		{
+			name:        "identical large integer is not a change",
+			before:      []byte(`{"id":9007199254740993}`),
+			after:       []byte(`{"id": 9007199254740993}`),
+			ext:         ".json",
+			profileType: ProfileTypeFreeform,
 		},
 		{
 			name:        "invalid before propagates error",


### PR DESCRIPTION
## Summary

`NormalizeJSON` used `json.Unmarshal`, which decodes JSON numbers as `float64` and loses precision for integers larger than 2^53. The write path (`formatJSON`, fixed in #104) already used `json.Decoder` + `UseNumber`, but the comparison/diff path (`NormalizeJSON`) was not updated, leaving the two asymmetric.

## Impact

`NormalizeJSON` is reached via `HasContentChanged` → `NormalizeByExtension` and is used by both the `run` / `pull` / `edit` no-op detection and `diff` rendering.

- **`diff`**: large integers were rendered with rounded values (e.g. actual `9007199254740993` shown as `...992`).
- **No-op detection**: a genuine change between two large integers that round to the same `float64` (e.g. `9007199254740992` vs `9007199254740993`) was treated as a no-op, so the AWS write was skipped.

Because both sides are rounded symmetrically, identical configs are never falsely reported as different.

## Changes

- Use `json.NewDecoder` + `UseNumber()` in `NormalizeJSON` so the comparison/diff path matches the write path's precision contract.
- Add regression tests:
  - `TestNormalizeJSON`: large-integer precision (single and multiple values)
  - `TestHasContentChanged`: large-integer change is detected / identical large integer is not a change

## Testing

- `mise run ci` passes (coverage 91.2%, `internal/config` 94.6%).
- Confirmed the new tests fail before the fix (reproducing the false no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)