### PR TITLE
fix: honor glob patterns in the multi-config -c flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,12 @@ Dev tools (Go toolchain, golangci-lint, gofumpt, tparse, octocov, goreleaser, te
 ./apcdeploy diff -c apcdeploy.yml --silent
 ./apcdeploy status -c apcdeploy.yml --silent
 
-# Multi-config (run / diff / pull / validate): pass -c repeatedly
+# Multi-config (run / diff / pull / validate): pass -c repeatedly or quote a glob
 ./apcdeploy diff -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml
-./apcdeploy run  -c environments/*.yml --parallel 3 --wait-bake
-./apcdeploy pull -c environments/*.yml --continue-on-error
+# Quote glob patterns so the shell does not expand them (apcdeploy expands them itself).
+# An unquoted glob is shell-expanded into positional args, which apcdeploy rejects.
+./apcdeploy run  -c 'environments/*.yml' --parallel 3 --wait-bake
+./apcdeploy pull -c 'environments/*.yml' --continue-on-error
 ```
 
 ### E2E Testing

--- a/README.md
+++ b/README.md
@@ -246,10 +246,11 @@ Deploy configuration changes:
 apcdeploy run -c apcdeploy.yml [--wait-deploy|--wait-bake] [--force]
 ```
 
-Pass `-c` multiple times to deploy several configs in one invocation.
+Pass `-c` multiple times to deploy several configs in one invocation. You can also pass a comma-separated list or a quoted glob pattern (quote it so the shell does not expand it). Comma-separation is handled by the CLI framework, so repeat `-c` for any path that itself contains a comma.
 
 ```bash
 apcdeploy run -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml --wait-bake
+apcdeploy run -c 'environments/*.yml' --wait-bake
 ```
 
 Options:

--- a/cmd/config_glob_test.go
+++ b/cmd/config_glob_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestResolveConfigTargets(t *testing.T) {
+	// Not parallel: each case mutates the configFiles package global.
+	tests := []struct {
+		name            string
+		args            []string
+		config          []string
+		want            []string
+		wantErrContains string
+	}{
+		{
+			name:   "single literal path",
+			args:   nil,
+			config: []string{"apcdeploy.yml"},
+			want:   []string{"apcdeploy.yml"},
+		},
+		{
+			name:   "repeated -c values pass through",
+			args:   nil,
+			config: []string{"a.yml", "b.yml"},
+			want:   []string{"a.yml", "b.yml"},
+		},
+		{
+			name:            "positional args rejected (unquoted glob leftovers)",
+			args:            []string{"env/stg.yml", "env/prod.yml"},
+			config:          []string{"env/dev.yml"},
+			wantErrContains: "quote glob patterns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(func() { configFiles = []string{defaultConfigFile} })
+			configFiles = tt.config
+
+			got, err := resolveConfigTargets(tt.args)
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result=%v)", got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandConfigGlobs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for _, name := range []string{"dev.yml", "stg.yml", "prod.yml"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("region: us-east-1\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pattern := filepath.Join(dir, "*.yml")
+	dev := filepath.Join(dir, "dev.yml")
+	prod := filepath.Join(dir, "prod.yml")
+	stg := filepath.Join(dir, "stg.yml")
+
+	tests := []struct {
+		name            string
+		paths           []string
+		want            []string
+		wantErrContains string
+	}{
+		{
+			name:  "glob expands and sorts",
+			paths: []string{pattern},
+			want:  []string{dev, prod, stg}, // filepath.Glob returns sorted
+		},
+		{
+			name:  "literal path without metachar passes through unchanged",
+			paths: []string{filepath.Join(dir, "missing.yml")},
+			want:  []string{filepath.Join(dir, "missing.yml")},
+		},
+		{
+			name:  "duplicates removed preserving first occurrence",
+			paths: []string{dev, pattern},
+			want:  []string{dev, prod, stg},
+		},
+		{
+			name:  "multiple globs preserve argument order",
+			paths: []string{filepath.Join(dir, "s*.yml"), filepath.Join(dir, "d*.yml")},
+			want:  []string{stg, dev},
+		},
+		{
+			name:            "pattern matching nothing is an error",
+			paths:           []string{filepath.Join(dir, "nope-*.yml")},
+			wantErrContains: "no files matched pattern",
+		},
+		{
+			name:            "malformed pattern is an error",
+			paths:           []string{filepath.Join(dir, "[")},
+			wantErrContains: "invalid glob pattern",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := expandConfigGlobs(tt.paths)
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result=%v)", got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -50,7 +50,11 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	ctx := commandContext(cmd)
 	rep := cli.GetReporter(isSilent())
 
-	targets, err := batch.LoadAll(configFiles)
+	paths, err := resolveConfigTargets(args)
+	if err != nil {
+		return err
+	}
+	targets, err := batch.LoadAll(paths)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -46,7 +46,11 @@ func runPull(cmd *cobra.Command, args []string) error {
 	ctx := commandContext(cmd)
 	rep := cli.GetReporter(isSilent())
 
-	targets, err := batch.LoadAll(configFiles)
+	paths, err := resolveConfigTargets(args)
+	if err != nil {
+		return err
+	}
+	targets, err := batch.LoadAll(paths)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"unicode/utf8"
 
@@ -252,6 +254,54 @@ func requireSingleConfig(cmdName string) (string, error) {
 	default:
 		return "", fmt.Errorf("%s does not support multiple -c flags (got %d)", cmdName, len(configFiles))
 	}
+}
+
+// resolveConfigTargets turns the -c values into a concrete, ordered,
+// de-duplicated list of config paths for the multi-config commands
+// (run/diff/pull/validate). Config files MUST be supplied via -c; glob
+// patterns MUST be quoted so the shell hands them to apcdeploy intact
+// (e.g. -c 'environments/*.yml'). An unquoted glob is expanded by the
+// shell into positional arguments instead, so any positional argument is
+// rejected with a hint to quote — this prevents the silent truncation that
+// would otherwise occur (only the first shell-expanded path reaching -c).
+func resolveConfigTargets(args []string) ([]string, error) {
+	if len(args) > 0 {
+		return nil, fmt.Errorf("unexpected arguments %q: pass config files via -c and quote glob patterns so the shell does not expand them, e.g. -c 'environments/*.yml'", args)
+	}
+	return expandConfigGlobs(configFiles)
+}
+
+// expandConfigGlobs expands each glob pattern in paths via filepath.Glob,
+// preserving order and removing duplicates. Entries without a glob
+// metacharacter pass through unchanged so a missing literal path still
+// produces LoadAll's clear "file not found"; a pattern that matches nothing
+// is an error.
+func expandConfigGlobs(paths []string) ([]string, error) {
+	out := make([]string, 0, len(paths))
+	seen := make(map[string]bool)
+	add := func(p string) {
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	for _, p := range paths {
+		if !strings.ContainsAny(p, "*?[") {
+			add(p)
+			continue
+		}
+		matches, err := filepath.Glob(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid glob pattern %q: %w", p, err)
+		}
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("no files matched pattern %q", p)
+		}
+		for _, m := range matches {
+			add(m)
+		}
+	}
+	return out, nil
 }
 
 // maxDescriptionLength matches the AppConfig API limit on the Description

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -97,7 +97,11 @@ func runRun(cmd *cobra.Command, args []string) error {
 
 	rep := cli.GetReporter(isSilent())
 
-	targets, err := batch.LoadAll(configFiles)
+	paths, err := resolveConfigTargets(args)
+	if err != nil {
+		return err
+	}
+	targets, err := batch.LoadAll(paths)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -54,7 +54,11 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	ctx := commandContext(cmd)
 	rep := cli.GetReporter(isSilent())
 
-	targets, err := batch.LoadAll(configFiles)
+	paths, err := resolveConfigTargets(args)
+	if err != nil {
+		return err
+	}
+	targets, err := batch.LoadAll(paths)
 	if err != nil {
 		return fmt.Errorf("failed to load configurations: %w", err)
 	}

--- a/e2e/cases/s3_multiconfig.sh
+++ b/e2e/cases/s3_multiconfig.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# S3: Multi-config orchestration — `-c` repeated for run/diff/pull.
+# S3: Multi-config orchestration — `-c` repeated (and quoted globs) for run/diff/pull.
 # Must run before any later section perturbs json-freeform/{dev,staging}.
 
 section "S3" "Multi-config"
@@ -48,6 +48,30 @@ apc_quiet pull --silent \
     -c "$mc_dir/dev/apcdeploy.yml" -c "$mc_dir/stg/apcdeploy.yml"
 assert_jq "$mc_dir/dev/data.json" '.mc == "dev-1"'
 assert_jq "$mc_dir/stg/data.json" '.mc == "stg-1"'
+
+step "quoted glob expands to every matching target"
+# Pattern is quoted so the shell passes it literally; apcdeploy expands it.
+# Both targets are changed so each emits its === <id> === diff header.
+printf '{"mc":"dev-3"}' > "$mc_dir/dev/data.json"
+printf '{"mc":"stg-3"}' > "$mc_dir/stg/data.json"
+glob_out=$(apc_stdout diff -c "$mc_dir/*/apcdeploy.yml" || true)
+assert_contains "$glob_out" "=== ${REGION}/${APP}/json-freeform/dev ===" "glob header dev"
+assert_contains "$glob_out" "=== ${REGION}/${APP}/json-freeform/staging ===" "glob header stg"
+
+step "quoted glob drives pull across both targets"
+apc_quiet pull --silent -c "$mc_dir/*/apcdeploy.yml"
+assert_jq "$mc_dir/dev/data.json" '.mc == "dev-1"'
+assert_jq "$mc_dir/stg/data.json" '.mc == "stg-1"'
+
+step "quoted glob drives validate across both targets"
+apc_quiet validate --silent -c "$mc_dir/*/apcdeploy.yml"
+
+step "glob matching no files is rejected"
+expect_fail "$APCDEPLOY_BIN" diff --silent -c "$mc_dir/nonexistent-*.yml"
+
+step "positional args (unquoted glob leftovers) are rejected"
+expect_fail "$APCDEPLOY_BIN" diff --silent \
+    -c "$mc_dir/dev/apcdeploy.yml" "$mc_dir/stg/apcdeploy.yml"
 
 step "path-level dedup: same -c twice is collapsed silently"
 apc_quiet diff --silent \

--- a/llms.md
+++ b/llms.md
@@ -602,8 +602,8 @@ apcdeploy validate -c apcdeploy.yml
 #### Examples
 
 ```bash
-# Validate every environment before deploying
-apcdeploy validate -c environments/*.yml --continue-on-error
+# Validate every environment before deploying (quote globs; see Multi-config Mode)
+apcdeploy validate -c 'environments/*.yml' --continue-on-error
 ```
 
 ### rollback command
@@ -710,22 +710,24 @@ Global flags (`-c`, `--silent`) have no effect on this command.
 
 Available for all commands:
 
-- `-c, --config <path>`: Configuration file path (default: `apcdeploy.yml`). May be repeated for `run` / `diff` / `pull` / `validate` to operate on several configs in one invocation (see "Multi-config Mode" below); all other commands accept exactly one `-c` and reject multiple.
+- `-c, --config <path>`: Configuration file path (default: `apcdeploy.yml`). For `run` / `diff` / `pull` / `validate` it may be repeated, comma-separated, or a quoted glob pattern to operate on several configs in one invocation (see "Multi-config Mode" below); all other commands accept exactly one `-c` and reject multiple.
 - `-s, --silent`: Suppress verbose output (see "Silent Mode" below).
 
 ## Multi-config Mode (run / diff / pull / validate)
 
-`run`, `diff`, `pull`, and `validate` support running against multiple configurations in one invocation. Pass `-c` repeatedly:
+`run`, `diff`, `pull`, and `validate` support running against multiple configurations in one invocation. Pass `-c` repeatedly, comma-separate values, or pass a **quoted** glob pattern:
 
 ```bash
 apcdeploy diff -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml
-apcdeploy run  -c environments/*.yml --parallel 3 --wait-bake
-apcdeploy pull -c environments/*.yml --continue-on-error
-apcdeploy validate -c environments/*.yml --continue-on-error
+apcdeploy run  -c 'environments/*.yml' --parallel 3 --wait-bake
+apcdeploy pull -c 'environments/*.yml' --continue-on-error
+apcdeploy validate -c 'environments/*.yml' --continue-on-error
 ```
 
 Behavior:
 
+- Glob patterns are expanded by apcdeploy itself (via Go's `filepath.Glob`), so they **must be quoted** (`-c 'environments/*.yml'`). An unquoted glob is expanded by the shell into positional arguments; apcdeploy rejects positional arguments with an error pointing back to quoting, rather than silently using only the first match. A pattern matching no files is an error; duplicates across patterns are de-duplicated preserving order.
+- Comma-separated values (`-c a.yml,b.yml`) are split by the CLI framework (Cobra), not by apcdeploy. Because of this, a path that itself contains a comma will be split incorrectly — repeat `-c` for such paths.
 - Each `-c` is loaded and validated up-front; any single load failure aborts the batch before any AWS call.
 - Targets are identified by the 4-tuple `region/app/profile/env`. Two configs that resolve to the same identifier produce `ErrDuplicateTarget`.
 - Default execution is fully parallel (equivalent to `--parallel 0`). Use `--parallel N` to cap concurrency or `--parallel 1` for strict serial order.
@@ -805,7 +807,7 @@ apcdeploy run -c environments/production/apcdeploy.yml
 Or deploy several at once via multi-config mode (see "Multi-config Mode" above):
 
 ```bash
-apcdeploy run -c environments/*/apcdeploy.yml --parallel 3
+apcdeploy run -c 'environments/*/apcdeploy.yml' --parallel 3
 ```
 
 ### CI/CD Pattern


### PR DESCRIPTION
## Summary

`run` / `diff` / `pull` / `validate` already documented glob usage in `-c` (e.g. `-c environments/*.yml`), but it never actually worked. This PR makes it work.

```bash
apcdeploy run -c 'environments/*.yml' --wait-bake
```

## The bug

README.md, llms.md (the user-facing manual served via `apcdeploy context`), and CLAUDE.md all showed glob examples like `-c environments/*.yml`. In practice the shell expanded the glob first, so `-c` captured only the **first** match and the rest were **silently dropped** (silent truncation). The documented feature was broken.

## Fix

- Add `resolveConfigTargets` / `expandConfigGlobs` helpers in `cmd/root.go`
  - Expand each `-c` value via `filepath.Glob` (order-preserving, de-duplicated)
  - Literal paths without a glob metacharacter (`*?[`) pass through unchanged (keeps the existing "file not found" behavior)
  - A pattern matching no files, or a malformed pattern, is an error
  - Positional arguments (the leftovers when an unquoted glob is shell-expanded) are rejected with an error that **points back to quoting**, instead of silently truncating to the first path
- Wire `run` / `diff` / `pull` / `validate` through these helpers
- Add unit tests (`cmd/config_glob_test.go`, table-driven, also asserting error message contents)
- Add e2e glob cases to S3 (multi-config): diff / pull / validate, no-match, positional-args rejection
- Fix the doc examples to the quoted form and note that comma-separation is handled by the CLI framework (Cobra)

## Design decisions

- Glob expansion lives in the `cmd` layer (treating globbing as a shell-replacement CLI concern), keeping `internal/batch` a pure "process the given paths" layer.
- Positional-argument rejection stays a hand-written check rather than `cobra.NoArgs`, to preserve the context-specific "quote your glob" hint instead of Cobra's generic message.

## Testing

- `mise run ci` passes (coverage held at 91.3%)
- Full e2e passes (15 sections / 80 steps; resources provisioned → tested → destroyed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)