### PR TITLE
chore: address post-v1.0.1 code review feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ When implementing new features or fixing bugs, follow these absolute rules:
 - **Code consistency**: Match existing code style and patterns
 - **CI validation**: Ensure `mise run ci` passes before considering work complete
 - **Test coverage**: Maintain or improve test coverage (never decrease it)
+- **English-only artifacts**: All repository content (code, comments, docs) and all GitHub artifacts (commit messages, PR titles/bodies, issue text) MUST be written in English.
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Pass `-c` multiple times to diff several configs in one invocation. Every diff b
 
 ```bash
 apcdeploy diff -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml
+apcdeploy diff -c 'environments/*.yml'
 ```
 
 Options:
@@ -353,6 +354,7 @@ Pass `-c` multiple times to pull several configurations in one invocation:
 
 ```bash
 apcdeploy pull -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml
+apcdeploy pull -c 'environments/*.yml'
 ```
 
 Options:
@@ -374,6 +376,7 @@ Pass `-c` multiple times to validate several configurations in one invocation:
 
 ```bash
 apcdeploy validate -c environments/dev.yml -c environments/stg.yml -c environments/prod.yml
+apcdeploy validate -c 'environments/*.yml'
 ```
 
 Options:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -278,10 +278,10 @@ func resolveConfigTargets(args []string) ([]string, error) {
 // is an error.
 func expandConfigGlobs(paths []string) ([]string, error) {
 	out := make([]string, 0, len(paths))
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	add := func(p string) {
-		if !seen[p] {
-			seen[p] = true
+		if _, ok := seen[p]; !ok {
+			seen[p] = struct{}{}
 			out = append(out, p)
 		}
 	}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -56,21 +56,12 @@ func TestRunValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "valid config but AWS error",
-			setupFiles: func(t *testing.T, dir string) string {
-				configPath := filepath.Join(dir, "valid.yml")
-				content := "application: test-app\nenvironment: test-env\nconfiguration_profile: test-profile\nregion: us-east-1\ndata_file: data.json\n"
-				if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
-					t.Fatalf("Failed to create test file: %v", err)
-				}
-				if err := os.WriteFile(filepath.Join(dir, "data.json"), []byte("{}"), 0o644); err != nil {
-					t.Fatalf("Failed to create data file: %v", err)
-				}
-				return configPath
-			},
-			wantErr: true, // Will fail due to AWS credentials/connection
-		},
+		// The success path and AWS-error paths for a valid config (resolve
+		// failure, client-init failure, schema violations) are covered
+		// deterministically with a mock client in
+		// internal/validate/executor_test.go. runValidate has no factory
+		// injection point, so exercising them here would require a real AWS
+		// call — kept out on purpose to keep this test hermetic.
 	}
 
 	for _, tt := range tests {

--- a/internal/config/featureflags.go
+++ b/internal/config/featureflags.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
@@ -72,37 +72,41 @@ func ValidateFeatureFlagsConstraints(data []byte) error {
 		if err != nil {
 			return fmt.Errorf("failed to build constraint schema for flag %q: %w", flagKey, err)
 		}
-
-		// Multi-variant flags carry their attribute values inside `_variants`
-		// (each variant has its own `attributeValues`) rather than at the top
-		// level. Validate each variant's attributeValues against the same
-		// constraint schema; otherwise validate the top-level value directly.
-		if variants, ok := flagVal["_variants"].([]any); ok && len(variants) > 0 {
-			for idx, v := range variants {
-				variant, ok := v.(map[string]any)
-				if !ok {
-					continue
-				}
-				av, _ := variant["attributeValues"].(map[string]any)
-				if av == nil {
-					// Validate an empty object so missing required attributes
-					// are still reported.
-					av = map[string]any{}
-				}
-				prefix := fmt.Sprintf("values/%s/_variants/%d/attributeValues", flagKey, idx)
-				if err := collectValueIssues(schemaJSON, av, prefix, &issues); err != nil {
-					return err
-				}
-			}
-		} else {
-			if err := collectValueIssues(schemaJSON, flagVal, "values/"+flagKey, &issues); err != nil {
-				return err
-			}
+		if err := collectFlagIssues(schemaJSON, flagKey, flagVal, &issues); err != nil {
+			return err
 		}
 	}
 
 	if len(issues) > 0 {
 		return &SchemaValidationError{Issues: issues}
+	}
+	return nil
+}
+
+// collectFlagIssues validates one flag's value(s) against schemaJSON. Multi-variant
+// flags carry their attribute values inside `_variants` (each variant has its own
+// `attributeValues`) rather than at the top level; single-variant flags hold the
+// value directly. Each variant's attributeValues is validated against the same
+// constraint schema.
+func collectFlagIssues(schemaJSON []byte, flagKey string, flagVal map[string]any, issues *[]string) error {
+	variants, ok := flagVal["_variants"].([]any)
+	if !ok || len(variants) == 0 {
+		return collectValueIssues(schemaJSON, flagVal, "values/"+flagKey, issues)
+	}
+	for idx, v := range variants {
+		variant, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		av, _ := variant["attributeValues"].(map[string]any)
+		if av == nil {
+			// Validate an empty object so missing required attributes are still reported.
+			av = map[string]any{}
+		}
+		prefix := fmt.Sprintf("values/%s/_variants/%d/attributeValues", flagKey, idx)
+		if err := collectValueIssues(schemaJSON, av, prefix, issues); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -190,11 +194,12 @@ func constraintToSchema(cons map[string]any) map[string]any {
 	return schema
 }
 
+// sortedKeys returns the keys of m in sorted order for deterministic iteration.
 func sortedKeys(m map[string]any) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	return keys
 }

--- a/internal/config/featureflags_constraints_test.go
+++ b/internal/config/featureflags_constraints_test.go
@@ -36,6 +36,25 @@ func TestValidateFeatureFlagsConstraints(t *testing.T) {
 			wantContains:  "values/f/color",
 		},
 		{
+			name: "value satisfies string pattern",
+			data: `{
+				"version": "1",
+				"flags": {"f": {"attributes": {"code": {"constraints": {"type": "string", "pattern": "^[a-z]+$"}}}}},
+				"values": {"f": {"enabled": true, "code": "abc"}}
+			}`,
+		},
+		{
+			name: "value violates string pattern",
+			data: `{
+				"version": "1",
+				"flags": {"f": {"attributes": {"code": {"constraints": {"type": "string", "pattern": "^[a-z]+$"}}}}},
+				"values": {"f": {"enabled": true, "code": "ABC123"}}
+			}`,
+			wantSchemaErr: true,
+			wantErr:       true,
+			wantContains:  "values/f/code",
+		},
+		{
 			name: "number below minimum",
 			data: `{
 				"version": "1",

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -23,13 +23,13 @@ func TestValidateAgainstJSONSchema(t *testing.T) {
 	}`
 
 	tests := []struct {
-		name         string
-		data         string
-		schema       string
-		forceDraft   *jsonschema.Draft
-		wantSchemaer bool   // expect *SchemaValidationError
-		wantErr      bool   // expect any error
-		wantContains string // substring expected in the error message
+		name          string
+		data          string
+		schema        string
+		forceDraft    *jsonschema.Draft
+		wantSchemaErr bool   // expect *SchemaValidationError
+		wantErr       bool   // expect any error
+		wantContains  string // substring expected in the error message
 	}{
 		{
 			name:    "valid data",
@@ -38,27 +38,27 @@ func TestValidateAgainstJSONSchema(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:         "type violation",
-			data:         `{"name": "alice", "age": "thirty"}`,
-			schema:       objectSchema,
-			wantSchemaer: true,
-			wantErr:      true,
-			wantContains: "/age",
+			name:          "type violation",
+			data:          `{"name": "alice", "age": "thirty"}`,
+			schema:        objectSchema,
+			wantSchemaErr: true,
+			wantErr:       true,
+			wantContains:  "/age",
 		},
 		{
-			name:         "missing required",
-			data:         `{"age": 30}`,
-			schema:       objectSchema,
-			wantSchemaer: true,
-			wantErr:      true,
-			wantContains: "name",
+			name:          "missing required",
+			data:          `{"age": 30}`,
+			schema:        objectSchema,
+			wantSchemaErr: true,
+			wantErr:       true,
+			wantContains:  "name",
 		},
 		{
-			name:         "additional property rejected",
-			data:         `{"name": "alice", "extra": true}`,
-			schema:       objectSchema,
-			wantSchemaer: true,
-			wantErr:      true,
+			name:          "additional property rejected",
+			data:          `{"name": "alice", "extra": true}`,
+			schema:        objectSchema,
+			wantSchemaErr: true,
+			wantErr:       true,
 		},
 		{
 			name:       "draft-4 schema without $schema using default draft",
@@ -71,12 +71,12 @@ func TestValidateAgainstJSONSchema(t *testing.T) {
 			// boolean exclusiveMinimum is draft-4 semantics; with forceDraft the
 			// document's draft-07 $schema is ignored and draft-4 rules apply, so
 			// value 5 fails minimum:5 + exclusiveMinimum:true.
-			name:         "force draft-4 overrides document $schema",
-			data:         `{"n": 5}`,
-			schema:       `{"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {"n": {"minimum": 5, "exclusiveMinimum": true}}}`,
-			forceDraft:   jsonschema.Draft4,
-			wantSchemaer: true,
-			wantErr:      true,
+			name:          "force draft-4 overrides document $schema",
+			data:          `{"n": 5}`,
+			schema:        `{"$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": {"n": {"minimum": 5, "exclusiveMinimum": true}}}`,
+			forceDraft:    jsonschema.Draft4,
+			wantSchemaErr: true,
+			wantErr:       true,
 		},
 		{
 			name:    "invalid schema json",
@@ -115,11 +115,11 @@ func TestValidateAgainstJSONSchema(t *testing.T) {
 			}
 
 			var sve *SchemaValidationError
-			isSchemaer := errors.As(err, &sve)
-			if tt.wantSchemaer && !isSchemaer {
+			isSchemaErr := errors.As(err, &sve)
+			if tt.wantSchemaErr && !isSchemaErr {
 				t.Fatalf("expected *SchemaValidationError, got %T: %v", err, err)
 			}
-			if !tt.wantSchemaer && isSchemaer {
+			if !tt.wantSchemaErr && isSchemaErr {
 				t.Fatalf("did not expect *SchemaValidationError, got: %v", err)
 			}
 			if tt.wantContains != "" && !strings.Contains(err.Error(), tt.wantContains) {

--- a/internal/init/initializer_test.go
+++ b/internal/init/initializer_test.go
@@ -760,26 +760,6 @@ func TestInitializer_GenerateFiles(t *testing.T) {
 			wantErr:   false,
 			wantFiles: []string{"apcdeploy.yml"},
 		},
-		{
-			name: "generate config and data files",
-			opts: &Options{
-				ConfigFile: "apcdeploy.yml",
-			},
-			result: &Result{
-				AppName:     "test-app",
-				ProfileName: "test-profile",
-				EnvName:     "test-env",
-				DataFile:    "data.json",
-				ConfigFile:  "apcdeploy.yml",
-				DeployedConfig: &awsInternal.DeployedConfigInfo{
-					VersionNumber: 1,
-					Content:       []byte(`{"key":"value"}`),
-					ContentType:   "application/json",
-				},
-			},
-			wantErr:   false,
-			wantFiles: []string{"apcdeploy.yml", "data.json"},
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Overview

Reviewed the `v1.0.1..HEAD` diff (validate command, FeatureFlags schema validation, glob support) with a multi-agent pass and applied only the low-risk, no-judgment findings. **No behavior changes.**

## Changes

### test
- `initializer_test.go`: remove a fully duplicated no-op test case (dead test)
- `schema_test.go`: rename `wantSchemaer` -> `wantSchemaErr` (consistent with adjacent tests)
- `featureflags_constraints_test.go`: add pass/fail cases for the `pattern` constraint
- `validate_test.go`: drop the case that depended on a real AWS connection and add a comment delegating to the mocked paths already covered in `internal/validate/executor_test.go` (keeps this test hermetic)

### refactor (no behavior change)
- `featureflags.go`: `sort.Strings` -> `slices.Sort` (match codebase convention), add a doc comment to `sortedKeys`
- `featureflags.go`: extract the per-variant loop in `ValidateFeatureFlagsConstraints` into `collectFlagIssues` to flatten nesting
- `root.go`: switch the glob dedup `seen` set to `map[string]struct{}` (match `batch/loader.go`)

### docs
- `README.md`: add glob examples to the diff/pull/validate sections (consistent with run)

## Findings deliberately left as-is

- **`-c` `StringSliceVarP` -> `StringArrayVarP`**: comma-separation is a documented public feature; the change has almost no benefit and would break backward compatibility, so kept as-is.
- **Splitting `resolveSchema`'s domain decision from its display strings**: `run`/`edit` rely on AWS's server-side validator as the authority and local validation is `validate`-only (per CLAUDE.md). Reuse is unlikely, so kept as-is.

## Verification

`mise run ci` passes (coverage 91.0%; `internal/validate` stays at 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)